### PR TITLE
Add owner related parameters (owner_notify_list, notify_owner_success…

### DIFF
--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -205,7 +205,7 @@ class HandlerBase(object):
         self._error_details = None
         self._handler_run = False
         self._instance_working_directory = None
-        self._notify_list = None
+        self._notification_results = None
         self._should_notify = None
 
         self._machine = Machine(model=self, states=HandlerBase.all_states, initial='HANDLER_INITIAL',
@@ -323,12 +323,12 @@ class HandlerBase(object):
         return self._instance_working_directory
 
     @property
-    def notify_list(self):
-        """Read-only property to retrieve the notification list and sent status of each recipient
+    def notification_results(self):
+        """Read-only property to retrieve the notification results, including the sent status of each recipient
 
         :return: NotifyList instance
         """
-        return self._notify_list
+        return self._notification_results
 
     @property
     def result(self):
@@ -538,7 +538,7 @@ class HandlerBase(object):
         self.logger.sysinfo("get_notify_runner -> '{runner}'".format(runner=notify_runner.__class__.__name__))
 
         if self._should_notify:
-            self._notify_list = notify_runner.run(self._should_notify)
+            self._notification_results = notify_runner.run(self._should_notify)
 
     def _notify_success(self):
         self._notify_common()

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -109,28 +109,85 @@ class TestDummyHandler(HandlerTestCase):
         mock_smtp.return_value.sendmail.return_value = {}
 
         handler = self.run_handler_with_exception(ComplianceCheckFailedError, NOT_NETCDF_NC_FILE,
-                                                  notify_params={'error_notify_list': ['email:nobody1@example.com',
-                                                                                       'email:nobody2@example.com']},
+                                                  notify_params={'notify_owner_error': False,
+                                                                 'owner_notify_list': ['email:owner1@example.com'],
+                                                                 'success_notify_list': ['email:nobody1@example.com',
+                                                                                         'email:nobody2@example.com'],
+                                                                 'error_notify_list': ['email:nobody3@example.com',
+                                                                                       'email:nobody4@example.com']},
                                                   dest_path_function=dest_path_testing)
+
+        expected_recipients = ['email:nobody3@example.com', 'email:nobody4@example.com']
+
         self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertEqual(len(handler.notify_list), 2)
-        self.assertTrue(handler.notify_list[0].notification_succeeded)
-        self.assertIsNone(handler.notify_list[0].error)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
+        self.assertTrue(all(r.error is None for r in handler.notify_list))
+
+    @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
+    def test_notify_owner_error(self, mock_smtp):
+        mock_smtp.return_value.sendmail.return_value = {}
+
+        handler = self.run_handler_with_exception(ComplianceCheckFailedError, NOT_NETCDF_NC_FILE,
+                                                  notify_params={'notify_owner_error': True,
+                                                                 'owner_notify_list': ['email:owner1@example.com'],
+                                                                 'success_notify_list': ['email:nobody1@example.com',
+                                                                                         'email:nobody2@example.com'],
+                                                                 'error_notify_list': ['email:nobody3@example.com',
+                                                                                       'email:nobody4@example.com']},
+                                                  dest_path_function=dest_path_testing)
+
+        expected_recipients = ['email:owner1@example.com', 'email:nobody3@example.com', 'email:nobody4@example.com']
+
+        self.assertIsInstance(handler.notify_list, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
+        self.assertTrue(all(r.error is None for r in handler.notify_list))
+
+    @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
+    def test_notify_system_error(self, mock_smtp):
+        mock_smtp.return_value.sendmail.return_value = {}
+
+        handler = self.run_handler_with_exception(InvalidInputFileError, get_nonexistent_path(),
+                                                  notify_params={'notify_owner_error': False,
+                                                                 'owner_notify_list': ['email:owner1@example.com'],
+                                                                 'success_notify_list': ['email:nobody1@example.com',
+                                                                                         'email:nobody2@example.com'],
+                                                                 'error_notify_list': ['email:nobody3@example.com',
+                                                                                       'email:nobody4@example.com']
+                                                                 },
+                                                  dest_path_function=dest_path_testing)
+
+        # a PipelineSystemError should *always* be sent to owner, regardless of 'notify_owner_error' flag
+        expected_recipients = ['email:owner1@example.com']
+
+        self.assertIsInstance(handler.notify_list, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
+        self.assertTrue(all(r.error is None for r in handler.notify_list))
 
     @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
     def test_notify_fail(self, mock_smtp):
         mock_smtp.return_value.sendmail.return_value = {}
 
         handler = self.run_handler(self.temp_nc_file,
-                                   notify_params={'success_notify_list': ['INVALID:nobody1@example.com',
-                                                                          'email:nobody2@example.com']},
+                                   notify_params={'notify_owner_error': False,
+                                                  'owner_notify_list': ['email:owner1@example.com'],
+                                                  'success_notify_list': ['email:nobody1@example.com',
+                                                                          'INVALID:nobody2@example.com'],
+                                                  'error_notify_list': ['email:nobody3@example.com',
+                                                                        'email:nobody4@example.com']
+                                                  },
                                    dest_path_function=dest_path_testing)
+
+        expected_recipients = ['email:nobody1@example.com', 'INVALID:nobody2@example.com']
+
         self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertEqual(len(handler.notify_list), 2)
-        self.assertFalse(handler.notify_list[0].notification_succeeded)
-        self.assertTrue(handler.notify_list[1].notification_succeeded)
-        self.assertIsInstance(handler.notify_list[0].error, InvalidRecipientError)
-        self.assertIsNone(handler.notify_list[1].error)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
+        self.assertTrue(handler.notify_list[0].notification_succeeded)
+        self.assertFalse(handler.notify_list[1].notification_succeeded)
+        self.assertIsNone(handler.notify_list[0].error)
+        self.assertIsInstance(handler.notify_list[1].error, InvalidRecipientError)
 
     @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
     def test_notify_success(self, mock_smtp):
@@ -138,14 +195,38 @@ class TestDummyHandler(HandlerTestCase):
 
         handler = self.run_handler(self.temp_nc_file,
                                    notify_params={'success_notify_list': ['email:nobody1@example.com',
-                                                                          'email:nobody2@example.com',
-                                                                          'email:nobody3@example.com',
-                                                                          'email:nobody4@example.com']},
+                                                                          'email:nobody2@example.com'],
+                                                  'error_notify_list': ['email:nobody3@example.com',
+                                                                        'email:nobody4@example.com']},
                                    dest_path_function=dest_path_testing)
+
+        expected_recipients = ['email:nobody1@example.com', 'email:nobody2@example.com']
+
         self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertEqual(len(handler.notify_list), 4)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
         self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
-        self.assertIsNone(handler.notify_list[0].error)
+        self.assertTrue(all(r.error is None for r in handler.notify_list))
+
+    @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
+    def test_notify_owner_success(self, mock_smtp):
+        mock_smtp.return_value.sendmail.return_value = {}
+
+        handler = self.run_handler(self.temp_nc_file,
+                                   notify_params={'notify_owner_success': True,
+                                                  'owner_notify_list': ['email:owner1@example.com'],
+                                                  'success_notify_list': ['email:nobody1@example.com',
+                                                                          'email:nobody2@example.com'],
+                                                  'error_notify_list': ['email:nobody3@example.com',
+                                                                        'email:nobody4@example.com']
+                                                  },
+                                   dest_path_function=dest_path_testing)
+
+        expected_recipients = ['email:owner1@example.com', 'email:nobody1@example.com', 'email:nobody2@example.com']
+
+        self.assertIsInstance(handler.notify_list, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
+        self.assertTrue(all(r.error is None for r in handler.notify_list))
 
     def test_property_default_addition_publish_type(self):
         handler = self.handler_class(self.temp_nc_file)

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -194,7 +194,8 @@ class TestDummyHandler(HandlerTestCase):
         mock_smtp.return_value.sendmail.return_value = {}
 
         handler = self.run_handler(self.temp_nc_file,
-                                   notify_params={'success_notify_list': ['email:nobody1@example.com',
+                                   notify_params={'owner_notify_list': ['email:owner1@example.com'],
+                                                  'success_notify_list': ['email:nobody1@example.com',
                                                                           'email:nobody2@example.com'],
                                                   'error_notify_list': ['email:nobody3@example.com',
                                                                         'email:nobody4@example.com']},

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -119,10 +119,10 @@ class TestDummyHandler(HandlerTestCase):
 
         expected_recipients = ['email:nobody3@example.com', 'email:nobody4@example.com']
 
-        self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
-        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
-        self.assertTrue(all(r.error is None for r in handler.notify_list))
+        self.assertIsInstance(handler.notification_results, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notification_results])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notification_results))
+        self.assertTrue(all(r.error is None for r in handler.notification_results))
 
     @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
     def test_notify_owner_error(self, mock_smtp):
@@ -139,10 +139,10 @@ class TestDummyHandler(HandlerTestCase):
 
         expected_recipients = ['email:owner1@example.com', 'email:nobody3@example.com', 'email:nobody4@example.com']
 
-        self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
-        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
-        self.assertTrue(all(r.error is None for r in handler.notify_list))
+        self.assertIsInstance(handler.notification_results, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notification_results])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notification_results))
+        self.assertTrue(all(r.error is None for r in handler.notification_results))
 
     @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
     def test_notify_system_error(self, mock_smtp):
@@ -161,10 +161,10 @@ class TestDummyHandler(HandlerTestCase):
         # a PipelineSystemError should *always* be sent to owner, regardless of 'notify_owner_error' flag
         expected_recipients = ['email:owner1@example.com']
 
-        self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
-        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
-        self.assertTrue(all(r.error is None for r in handler.notify_list))
+        self.assertIsInstance(handler.notification_results, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notification_results])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notification_results))
+        self.assertTrue(all(r.error is None for r in handler.notification_results))
 
     @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
     def test_notify_fail(self, mock_smtp):
@@ -182,12 +182,12 @@ class TestDummyHandler(HandlerTestCase):
 
         expected_recipients = ['email:nobody1@example.com', 'INVALID:nobody2@example.com']
 
-        self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
-        self.assertTrue(handler.notify_list[0].notification_succeeded)
-        self.assertFalse(handler.notify_list[1].notification_succeeded)
-        self.assertIsNone(handler.notify_list[0].error)
-        self.assertIsInstance(handler.notify_list[1].error, InvalidRecipientError)
+        self.assertIsInstance(handler.notification_results, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notification_results])
+        self.assertTrue(handler.notification_results[0].notification_succeeded)
+        self.assertFalse(handler.notification_results[1].notification_succeeded)
+        self.assertIsNone(handler.notification_results[0].error)
+        self.assertIsInstance(handler.notification_results[1].error, InvalidRecipientError)
 
     @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
     def test_notify_success(self, mock_smtp):
@@ -203,10 +203,10 @@ class TestDummyHandler(HandlerTestCase):
 
         expected_recipients = ['email:nobody1@example.com', 'email:nobody2@example.com']
 
-        self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
-        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
-        self.assertTrue(all(r.error is None for r in handler.notify_list))
+        self.assertIsInstance(handler.notification_results, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notification_results])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notification_results))
+        self.assertTrue(all(r.error is None for r in handler.notification_results))
 
     @mock.patch('aodncore.pipeline.steps.notify.smtplib.SMTP')
     def test_notify_owner_success(self, mock_smtp):
@@ -224,10 +224,10 @@ class TestDummyHandler(HandlerTestCase):
 
         expected_recipients = ['email:owner1@example.com', 'email:nobody1@example.com', 'email:nobody2@example.com']
 
-        self.assertIsInstance(handler.notify_list, NotifyList)
-        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notify_list])
-        self.assertTrue(all(r.notification_succeeded for r in handler.notify_list))
-        self.assertTrue(all(r.error is None for r in handler.notify_list))
+        self.assertIsInstance(handler.notification_results, NotifyList)
+        self.assertItemsEqual(expected_recipients, [n.raw_string for n in handler.notification_results])
+        self.assertTrue(all(r.notification_succeeded for r in handler.notification_results))
+        self.assertTrue(all(r.error is None for r in handler.notification_results))
 
     def test_property_default_addition_publish_type(self):
         handler = self.handler_class(self.temp_nc_file)


### PR DESCRIPTION
…, notify_owner_error) to the notify_params dict. Assemble recipients into "should_notify" attribute, depending on scenario and notify_params contents.