### PR TITLE
Move mock, pyinotify and scandir from requirements file to extras_req…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,8 @@ compliance-checker==2.3.1
 enum34==1.1.6
 Jinja2==2.9.6
 jsonschema==2.6.0
-mock==2.0.0 ; python_version < '3.3'
 numpy>=1.13.0
 paramiko==2.2.1
-pyinotify==0.9.6
-scandir==1.6 ; python_version < '3.5'
 six==1.10.0
 SQLAlchemy==1.1.11
 tabulate==0.7.7

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,12 @@ from aodncore.version import __version__
 ENTRY_POINTS = {
 }
 
+EXTRAS_REQUIRE = {
+    ':platform_system == "Linux"': ['pyinotify == 0.9.6'],
+    ':python_version < "3.3"': ['mock == 2.0.0'],
+    ':python_version < "3.5"': ['scandir == 1.6'],
+}
+
 PACKAGE_DATA = {
     'aodncore': [
         'pipeline/templates/*.j2',
@@ -35,6 +41,7 @@ setup(
     description='AODN pipeline library',
     zip_safe=False,
     install_requires=requires,
+    extras_require=EXTRAS_REQUIRE,
     test_suite='test_aodncore',
     entry_points=ENTRY_POINTS
 )


### PR DESCRIPTION
…uire so that conditional dependencies are included in the wheel package

This ensures the package metadata is generated like this, with the appropriate environment markers:

```
Requires-Dist: pip
Requires-Dist: boto3 (==1.4.4)
Requires-Dist: cc-plugin-imos (>=1.1.1)
Requires-Dist: celery (==4.0.2)
Requires-Dist: compliance-checker (==2.3.1)
Requires-Dist: enum34 (==1.1.6)
Requires-Dist: Jinja2 (==2.9.6)
Requires-Dist: jsonschema (==2.6.0)
Requires-Dist: numpy (>=1.13.0)
Requires-Dist: paramiko (==2.2.1)
Requires-Dist: six (==1.10.0)
Requires-Dist: tabulate (==0.7.7)
Requires-Dist: transitions (==0.5.3)
Requires-Dist: pyinotify (==0.9.6); platform_system == "Linux"
Requires-Dist: mock (==2.0.0); python_version < "3.3"
Requires-Dist: scandir (==1.6); python_version < "3.5"
```