### PR TITLE
Fixes #55. Only attempt to set 'is_overwrite' for files expected to b…

### DIFF
--- a/aodncore/pipeline/exceptions.py
+++ b/aodncore/pipeline/exceptions.py
@@ -4,6 +4,7 @@ __all__ = [
     'PipelineProcessingError',
     'PipelineSystemError',
     'ComplianceCheckFailedError',
+    'AttributeNotSetError',
     'DuplicatePipelineFileError',
     'FileDeleteFailedError',
     'FileUploadFailedError',
@@ -61,6 +62,10 @@ class InvalidFileFormatError(PipelineProcessingError):
 
 
 # System errors
+
+class AttributeNotSetError(PipelineSystemError):
+    pass
+
 
 class DuplicatePipelineFileError(PipelineSystemError):
     pass

--- a/aodncore/testlib/testutil.py
+++ b/aodncore/testlib/testutil.py
@@ -58,8 +58,8 @@ class NullUploadRunner(BaseUploadRunner):
     def _get_absolute_dest_uri(self, pipeline_file):
         return "null://{dest_path}".format(dest_path=pipeline_file.dest_path)
 
-    def set_is_overwrite(self, pipeline_files):
-        pass
+    def _get_is_overwrite(self, pipeline_file, abs_path):
+        return not self.fail
 
     def run(self, pipeline_files):
         self.call_count += 1
@@ -74,8 +74,7 @@ class NullUploadRunner(BaseUploadRunner):
             raise AssertionError("run method not called")
 
     def assert_not_called(self):
-        if self.call_count != 0:
-            raise AssertionError("run method call_count: {call_count}".format(call_count=self.call_count))
+        self.assert_call_count(0)
 
 
 def dest_path_testing(filename):

--- a/test_aodncore/pipeline/steps/test_upload.py
+++ b/test_aodncore/pipeline/steps/test_upload.py
@@ -205,6 +205,21 @@ class TestBaseUploadRunner(BaseTestCase):
         runner.run(collection)
         self.assertTrue(collection[0].is_stored)
 
+    def test_set_is_overwrite_with_no_action_file(self):
+        collection = get_upload_collection()
+
+        temp_file = PipelineFile(self.temp_nc_file)
+        self.assertIsNone(temp_file.dest_path)
+        self.assertIs(temp_file.publish_type, PipelineFilePublishType.NO_ACTION)
+        collection.add(temp_file)
+
+        runner = NullUploadRunner("/")
+        try:
+            runner.set_is_overwrite(collection)
+        except Exception as e:
+            raise AssertionError(
+                "unexpected exception raised. {cls} {msg}".format(cls=e.__class__.__name__, msg=e))
+
 
 class TestFileUploadRunner(BaseTestCase):
     @mock.patch('aodncore.pipeline.steps.upload.mkdir_p')


### PR DESCRIPTION
…e uploaded.

Fixes: https://github.com/aodn/python-aodncore/issues/55

@bpasquer and @lbesnard have independently encountered this bug, related to trying to set "is_overwrite" for files that have no dest_path set, causing the unhandled NoneType exception.

This includes a minor refactor of the upload runner abstract class, in order to make 'set_is_overwrite' a base class method, which calls the abstract, implementation specific '_get_is_overwrite' method in the child classes.
