### PR TITLE
Harvester extra params

### DIFF
--- a/aodncore/pipeline/exceptions.py
+++ b/aodncore/pipeline/exceptions.py
@@ -19,6 +19,7 @@ __all__ = [
     'InvalidPathFunctionError',
     'InvalidHandlerError',
     'InvalidHarvesterError',
+    'InvalidHarvestMapError',
     'InvalidInputFileError',
     'InvalidRecipientError',
     'InvalidUploadUrlError',
@@ -105,6 +106,10 @@ class InvalidHandlerError(PipelineSystemError):
 
 
 class InvalidHarvesterError(PipelineSystemError):
+    pass
+
+
+class InvalidHarvestMapError(PipelineSystemError):
     pass
 
 

--- a/aodncore/testlib/conf/trigger.conf
+++ b/aodncore/testlib/conf/trigger.conf
@@ -1,6 +1,6 @@
 {
     "zzz_my_test_harvester": {
-        "exec": "echo --context_param paramFile=\"/usr/local/talend/jobs/param_file.conf\" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}",
+        "exec": "echo zzz_my_test_harvester --context_param paramFile=\"/usr/local/talend/jobs/param_file.conf\" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}",
         "events": [
             {
                 "regex": [
@@ -10,8 +10,14 @@
         ]
     },
     "aaa_my_test_harvester": {
-        "exec": "echo --context_param paramFile=\"/usr/local/talend/jobs/param_file.conf\" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}",
+        "exec": "echo aaa_my_test_harvester --context_param paramFile=\"/usr/local/talend/jobs/param_file.conf\" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}",
         "events": [
+            {
+                "regex": [
+                    ".*"
+                ],
+                "extra_params": "--collection my_test_collection"
+            },
             {
                 "regex": [
                     ".*"
@@ -20,7 +26,7 @@
         ]
     },
     "mmm_my_test_harvester": {
-        "exec": "echo --context_param paramFile=\"/usr/local/talend/jobs/param_file.conf\" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}",
+        "exec": "echo mmm_my_test_harvester --context_param paramFile=\"/usr/local/talend/jobs/param_file.conf\" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}",
         "events": [
             {
                 "regex": [

--- a/aodncore/util/misc.py
+++ b/aodncore/util/misc.py
@@ -158,7 +158,10 @@ def merge_dicts(*args):
 
     :return: None
     """
-    master = {}
+    if args and isinstance(args[0], OrderedDict):
+        master = OrderedDict()
+    else:
+        master = {}
 
     for current_dict in args:
         for k, v in six.iteritems(current_dict):

--- a/test_aodncore/pipeline/steps/test_harvest.py
+++ b/test_aodncore/pipeline/steps/test_harvest.py
@@ -84,9 +84,16 @@ class TestTalendHarvesterRunner(BaseTestCase):
 
         called_commands = [c[1][0] for c in mock_subprocess.Popen.mock_calls if c[1]]
 
+        self.assertTrue(called_commands[0].startswith('echo zzz_my_test_harvester '))
         self.assertFalse(called_commands[0].endswith(expected_extra_params))
+
+        self.assertTrue(called_commands[1].startswith('echo aaa_my_test_harvester '))
         self.assertTrue(called_commands[1].endswith(expected_extra_params))
+
+        self.assertTrue(called_commands[2].startswith('echo aaa_my_test_harvester '))
         self.assertFalse(called_commands[2].endswith(expected_extra_params))
+
+        self.assertTrue(called_commands[3].startswith('echo mmm_my_test_harvester '))
         self.assertFalse(called_commands[3].endswith(expected_extra_params))
 
     @patch('aodncore.util.process.subprocess')

--- a/test_aodncore/pipeline/test_configlib.py
+++ b/test_aodncore/pipeline/test_configlib.py
@@ -55,7 +55,7 @@ REFERENCE_TRIGGER_CONFIG = OrderedDict([
     ("zzz_my_test_harvester", OrderedDict([
         (
             "exec",
-            'echo --context_param paramFile="/usr/local/talend/jobs/param_file.conf" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}'
+            'echo zzz_my_test_harvester --context_param paramFile="/usr/local/talend/jobs/param_file.conf" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}'
         ),
         (
             "events", [
@@ -68,20 +68,24 @@ REFERENCE_TRIGGER_CONFIG = OrderedDict([
     ("aaa_my_test_harvester", OrderedDict([
         (
             "exec",
-            'echo --context_param paramFile="/usr/local/talend/jobs/param_file.conf" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}'
+            'echo aaa_my_test_harvester --context_param paramFile="/usr/local/talend/jobs/param_file.conf" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}'
         ),
         (
             "events", [
                 OrderedDict([
+                    ("regex", [".*"]),
+                    ("extra_params", "--collection my_test_collection")
+                ]),
+                OrderedDict([
                     ("regex", [".*"])
                 ])
             ]
-        )
+        ),
     ])),
     ("mmm_my_test_harvester", OrderedDict([
         (
             "exec",
-            'echo --context_param paramFile="/usr/local/talend/jobs/param_file.conf" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}'
+            'echo mmm_my_test_harvester --context_param paramFile="/usr/local/talend/jobs/param_file.conf" --context_param base=%{base} --context_param fileList=%{file_list} --context_param logDir=%{log_dir}'
         ),
         (
             "events", [

--- a/test_aodncore/util/test_misc.py
+++ b/test_aodncore/util/test_misc.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import uuid
+from collections import OrderedDict
 
 import six
 
@@ -188,6 +189,13 @@ class TestUtilMisc(BaseTestCase):
             }
         }
 
+        reference_ordered_dict = OrderedDict(sorted(reference_dict.items()))
+        reference_ordered_dict['key7'] = {
+            'subkey4': {
+                'subsubkey2': 'subsubvalue3'
+            }
+        }
+
         dict1 = {
             'key1': 'value1',
             'key2': 'value2',
@@ -228,9 +236,20 @@ class TestUtilMisc(BaseTestCase):
                 }
             }
         }
+        dict8 = {
+            'key7': {
+                'subkey4': {
+                    'subsubkey2': 'subsubvalue3'
+                }
+            }
+        }
 
         merged_dict = merge_dicts(dict1, dict2, dict3, dict4, dict5, dict6, dict7)
         self.assertDictEqual(merged_dict, reference_dict)
+
+        ordered_merged_dict = merge_dicts(reference_ordered_dict, dict8)
+        self.assertIsInstance(ordered_merged_dict, OrderedDict)
+        self.assertDictEqual(ordered_merged_dict, reference_ordered_dict)
 
     def test_slice_sequence(self):
         test_sequence = ('a', 'b', 'c')


### PR DESCRIPTION
Fixes https://github.com/aodn/python-aodncore/issues/46

This will obviously need some testing in PO box and RC before being accepted for prod.

The key differences are:
* the various "harvester map" dicts have been consolidated into the same structure for consistency
* Similar to the Ruby trigger script, there is now an additional layer in the looping, essentially a "for each event"

It would be nice to revisit with a refactor to get rid of some code duplication (for example between the run_* methods) but I didn't want to change to much at once.

In addition, this obviously makes the undo scenarios more complicated, so we should revisit that at some point, maybe in combination with the refactor I mentioned above. Probably should be a bit less "procedural", which is what I was getting at when introducing the TriggerEvent class and shared map data structure, because the more we want to do with undo behaviour the more structured we will need things like that.
