### PR TITLE
Fixes #67. Update success handler method to create a new list for suc…

### DIFF
--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -964,8 +964,10 @@ class HandlerBase(object):
     def _handle_success(self):
         self._result = HandlerResult.SUCCESS
 
+        should_notify = []
         notify_params_dict = self.notify_params or {}
-        should_notify = notify_params_dict.get('success_notify_list', [])
+
+        should_notify.extend(notify_params_dict.get('success_notify_list', []))
 
         if notify_params_dict.get('notify_owner_success', False):
             should_notify.extend(notify_params_dict.get('owner_notify_list', []))


### PR DESCRIPTION
…cess notifications instead of modifying list from configuration object.

Note the _handle_error method didn't have this bug, as it was doing this same thing of creating a fresh list and then extending it.

It highlights another bug where the config should *not* be mutable, since the same watch_config object is shared between task instances, which is why the list was growing with each task. I'll log that separately though.