### PR TITLE
Resolve step fixes

### DIFF
--- a/aodncore/pipeline/steps/resolve.py
+++ b/aodncore/pipeline/steps/resolve.py
@@ -109,7 +109,7 @@ class BaseManifestResolveRunner(BaseResolveRunner):
         if resolve_params is None:
             resolve_params = {}
 
-        relative_path_root = resolve_params.pop('relative_path_root', self._config.pipeline_config['global']['wip_dir'])
+        relative_path_root = resolve_params.get('relative_path_root', self._config.pipeline_config['global']['wip_dir'])
         self.relative_path_root = relative_path_root
 
     def get_abs_path(self, path):

--- a/aodncore/pipeline/steps/resolve.py
+++ b/aodncore/pipeline/steps/resolve.py
@@ -194,9 +194,6 @@ class RsyncManifestResolveRunner(BaseManifestResolveRunner):
     @classmethod
     def classify_line(cls, line):
 
-        if line == cls.HEADER_LINE:
-            return RsyncManifestLine(None, RsyncLineType.HEADER)
-
         match = cls.RECORD_PATTERN.match(line)
         try:
             matchdict = match.groupdict()
@@ -212,6 +209,8 @@ class RsyncManifestResolveRunner(BaseManifestResolveRunner):
         elif cls.DELETE_PATTERN.match(operation):
             delete_type = RsyncLineType.DIRECTORY_DELETE if path.endswith('/') else RsyncLineType.FILE_DELETE
             return RsyncManifestLine(path, delete_type)
+        elif line == cls.HEADER_LINE:
+            return RsyncManifestLine(None, RsyncLineType.HEADER)
         else:
             return RsyncManifestLine(None, RsyncLineType.INVALID)  # pragma: no cover
 
@@ -221,7 +220,7 @@ class RsyncManifestResolveRunner(BaseManifestResolveRunner):
                 line = line_newline.rstrip(os.linesep)
                 record = self.classify_line(line)
 
-                if record.type in (RsyncLineType.HEADER, RsyncLineType.INVALID):
+                if record.type not in {RsyncLineType.FILE_ADD, RsyncLineType.FILE_DELETE}:
                     continue
 
                 abs_path = self.get_abs_path(record.path)


### PR DESCRIPTION
Fix bug with manifest file handling by not popping the value out of the dictionary. Add a couple of optimisations for large rsync manifest files.

This overlaps with the following issue regarding config mutability: https://github.com/aodn/python-aodncore/issues/69