### PR TITLE
Upgrade to compliance checker 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pip
 boto3==1.4.4
-cc-plugin-imos>=1.2.0
+cc-plugin-imos>=1.3.0
 celery==4.0.2
-compliance-checker==3.1.1
+compliance-checker==4.0.1
 enum34==1.1.6
 Jinja2==2.9.6
 jsonschema==2.6.0


### PR DESCRIPTION
~~DO NOT MERGE until the chef code used to pin the checker version has been removed.~~

This simply updates the requirements file to specify the latest version of the compliance checker, and the imos plugin.