### PR TITLE
Input file archive path

### DIFF
--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -10,7 +10,7 @@ from .common import (FileType, PipelineFilePublishType, PipelineFileCheckType, v
 from .exceptions import DuplicateUniqueAttributeError, DuplicatePipelineFileError, MissingFileError
 from ..util import (IndexedSet, format_exception, get_file_checksum, iter_public_attributes, matches_regexes,
                     slice_sequence, validate_bool, validate_callable, validate_dict, validate_mapping,
-                    validate_nonstring_iterable, validate_regex, validate_string, validate_type)
+                    validate_nonstring_iterable, validate_regex, validate_relative_path, validate_string, validate_type)
 
 __all__ = [
     'PipelineFileCollection',
@@ -135,8 +135,7 @@ class PipelineFile(object):
 
     @archive_path.setter
     def archive_path(self, archive_path):
-        if os.path.isabs(archive_path):
-            raise ValueError('archive_path must be a relative path')
+        validate_relative_path(archive_path)
         self._archive_path = archive_path
         self._post_property_update({'archive_path': archive_path})
 
@@ -177,8 +176,7 @@ class PipelineFile(object):
 
     @dest_path.setter
     def dest_path(self, dest_path):
-        if os.path.isabs(dest_path):
-            raise ValueError('dest_path must be a relative path')
+        validate_relative_path(dest_path)
         self._dest_path = dest_path
         self._post_property_update({'dest_path': dest_path})
 

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -15,9 +15,22 @@ from ..util import (IndexedSet, format_exception, get_file_checksum, iter_public
 __all__ = [
     'PipelineFileCollection',
     'PipelineFile',
+    'ensure_pipelinefilecollection',
     'validate_pipelinefilecollection',
+    'validate_pipelinefile_or_pipelinefilecollection',
     'validate_pipelinefile_or_string'
 ]
+
+
+def ensure_pipelinefilecollection(o):
+    """Function to accept either a single PipelineFile OR and PipelineFileCollection and ensure that a
+    PipelineFileCollection object is returned in either case
+
+    :param o: PipelineFile or PipelineFileCollection object
+    :return: PipelineFileCollection object
+    """
+    validate_pipelinefile_or_pipelinefilecollection(o)
+    return o if isinstance(o, PipelineFileCollection) else PipelineFileCollection(o)
 
 
 class PipelineFile(object):
@@ -815,4 +828,5 @@ class PipelineFileCollection(MutableSet):
 
 
 validate_pipelinefilecollection = validate_type(PipelineFileCollection)
+validate_pipelinefile_or_pipelinefilecollection = validate_type((PipelineFile, PipelineFileCollection))
 validate_pipelinefile_or_string = validate_type((PipelineFile, six.string_types))

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -17,7 +17,7 @@ from .schema import validate_check_params, validate_harvest_params, validate_not
 from .statequery import StateQuery
 from .steps import (get_check_runner, get_harvester_runner, get_notify_runner, get_resolve_runner, get_store_runner)
 from ..util import (discover_entry_points, format_exception, get_file_checksum, iter_public_attributes, merge_dicts,
-                    validate_bool, TemporaryDirectory)
+                    validate_relative_path, TemporaryDirectory)
 from ..version import __version__ as _aodncore_version
 
 __all__ = [
@@ -300,6 +300,8 @@ class HandlerBase(object):
         self._error_details = None
         self._file_collection = None
         self._handler_run = False
+        self._input_file_archive_path = None
+        self._input_file_object = None
         self._instance_working_directory = None
         self._notification_results = None
         self._should_notify = None
@@ -313,7 +315,7 @@ class HandlerBase(object):
 
     def __iter__(self):
         ignored_attributes = {'celery_task', 'config', 'default_addition_publish_type', 'default_deletion_publish_type',
-                              'logger', 'state', 'trigger'}
+                              'input_file_object', 'logger', 'state', 'trigger'}
         ignored_attributes.update("is_{state}".format(state=s) for s in self.all_states)
 
         return iter_public_attributes(self, ignored_attributes)
@@ -421,6 +423,35 @@ class HandlerBase(object):
         return self._instance_working_directory
 
     @property
+    def input_file_archive_path(self):
+        """Property used to determine the archive path for the original input file
+
+        :return: string containing the archive path
+        :rtype: :class:`str`
+        """
+        if not self._input_file_archive_path:
+            self.input_file_archive_path = os.path.join(self._pipeline_name, os.path.basename(self.input_file))
+        return self._input_file_archive_path
+
+    @input_file_archive_path.setter
+    def input_file_archive_path(self, path):
+        validate_relative_path(path)
+        self._input_file_archive_path = path
+
+    @property
+    def input_file_object(self):
+        """Read-only property to access the original input file represented as a PipelineFile object
+
+        :return: input file object
+        :rtype: :py:class:`PipelineFile`
+        """
+        if not self._input_file_object:
+            input_file_object = PipelineFile(self.input_file, file_update_callback=self._file_update_callback)
+            input_file_object.publish_type = PipelineFilePublishType.ARCHIVE_ONLY
+            self._input_file_object = input_file_object
+        return self._input_file_object
+
+    @property
     def module_versions(self):
         """Read-only property to access module versions
 
@@ -511,20 +542,6 @@ class HandlerBase(object):
         self._default_deletion_publish_type = publish_type
 
     @property
-    def is_archived(self):
-        """Boolean property indicating whether the :py:attr:`input_file` has been archived
-
-        :return: whether the :py:attr:`input_file` has been archived or not
-        :rtype: :class:`bool`
-        """
-        return self._is_archived
-
-    @is_archived.setter
-    def is_archived(self, is_archived):
-        validate_bool(is_archived)
-        self._is_archived = is_archived
-
-    @property
     def collection_dir(self):
         """Temporary subdirectory where the *initial* input file collection will be unpacked
 
@@ -596,19 +613,15 @@ class HandlerBase(object):
         if files_to_check:
             check_runner.run(files_to_check)
 
-    def _archive(self, store_runner):
+    def _archive(self):
         files_to_archive = self.file_collection.filter_by_bool_attribute('pending_archive')
 
-        if self.archive_input_file:
-            input_file_obj = PipelineFile(self.input_file, archive_path=os.path.join(self._pipeline_name,
-                                                                                     os.path.basename(self.input_file)))
-            input_file_obj.publish_type = PipelineFilePublishType.ARCHIVE_ONLY
-            infile_collection = PipelineFileCollection(input_file_obj)
-            store_runner.run(infile_collection)
-            self.is_archived = input_file_obj.is_archived
-
         if files_to_archive:
-            store_runner.run(files_to_archive)
+            self._upload_runner_archive.run(files_to_archive)
+
+        if self.archive_input_file:
+            self.input_file_object.archive_path = self.input_file_archive_path
+            self._upload_runner_archive.run(self.input_file_object)
 
     def _harvest(self):
         harvest_runner = get_harvester_runner(self.harvest_type, self._upload_runner.broker, self.harvest_params,
@@ -628,7 +641,7 @@ class HandlerBase(object):
     def _publish(self):
         self.file_collection.set_archive_paths(self._archive_path_function_ref)
         self.file_collection.validate_attribute_uniqueness('archive_path')
-        self._archive(self._upload_runner_archive)
+        self._archive()
 
         self.file_collection.set_dest_paths(self._dest_path_function_ref)
         self.file_collection.validate_attribute_uniqueness('dest_path')

--- a/aodncore/util/__init__.py
+++ b/aodncore/util/__init__.py
@@ -6,7 +6,7 @@ from .misc import (CaptureStdIO, LoggingContext, TemplateRenderer, WriteOnceOrde
                    format_exception, is_function, is_nonstring_iterable, is_valid_email_address, iter_public_attributes,
                    matches_regexes, merge_dicts, slice_sequence, str_to_list, validate_bool, validate_callable,
                    validate_dict, validate_int, validate_mapping, validate_mandatory_elements, validate_membership,
-                   validate_nonstring_iterable, validate_regex, validate_string, validate_type)
+                   validate_nonstring_iterable, validate_regex, validate_relative_path, validate_string, validate_type)
 from .process import SystemProcess
 
 __all__ = [
@@ -52,6 +52,7 @@ __all__ = [
     'validate_membership',
     'validate_nonstring_iterable',
     'validate_regex',
+    'validate_relative_path',
     'validate_string',
     'validate_type',
 ]

--- a/aodncore/util/misc.py
+++ b/aodncore/util/misc.py
@@ -4,6 +4,7 @@ These are typically functions which query, manipulate or transform Python object
 """
 
 import logging
+import os
 import re
 import sys
 import types
@@ -36,6 +37,7 @@ __all__ = [
     'validate_membership',
     'validate_nonstring_iterable',
     'validate_regex',
+    'validate_relative_path',
     'validate_string',
     'validate_type',
     'CaptureStdIO',
@@ -265,6 +267,11 @@ def validate_regex(o):
         re.compile(o)
     except re.error as e:
         raise ValueError("invalid regex '{o}'. {e}".format(o=o, e=format_exception(e)))
+
+
+def validate_relative_path(o):
+    if os.path.isabs(o):
+        raise ValueError("path '{o}' must be a relative path".format(o=o))
 
 
 def validate_mandatory_elements(mandatory, actual, name='item'):

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -110,9 +110,29 @@ class TestDummyHandler(HandlerTestCase):
         self.assertTrue(handler.file_collection[0].is_archived)
 
     def test_archive_input_file(self):
-        handler = self.run_handler(self.temp_nc_file, archive_path_function=dest_path_testing, archive_input_file=True)
-        self.assertTrue(handler.is_archived)
-        self.assertTrue(handler.file_collection[0].is_archived)
+        handler = self.run_handler(GOOD_ZIP, archive_path_function=dest_path_testing, archive_input_file=True)
+        self.assertTrue(handler.input_file_object.is_archived)
+
+    def test_archive_input_file_custom_path(self):
+        expected_path = 'custom/relative/path'
+
+        handler = self.handler_class(GOOD_ZIP, archive_path_function=dest_path_testing, archive_input_file=True)
+        handler.input_file_archive_path = expected_path
+        handler.run()
+
+        self.assertTrue(handler.input_file_object.is_archived)
+        self.assertEqual(handler.input_file_object.archive_path, expected_path)
+
+    def test_input_file_archive_path(self):
+        handler = self.handler_class(self.temp_nc_file)
+        with self.assertRaises(ValueError):
+            handler.input_file_archive_path = '/absolute/path/MYFACILITY/path/to/file.txt'
+
+        try:
+            handler.input_file_archive_path = 'relative/path/MYFACILITY/path/to/file.txt'
+        except Exception as e:
+            raise AssertionError(
+                "unexpected exception raised. {cls} {msg}".format(cls=e.__class__.__name__, msg=e))
 
     def test_invalid_check_suite(self):
         self.run_handler_with_exception(InvalidCheckSuiteError, NOT_NETCDF_NC_FILE,

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -5,8 +5,8 @@ from collections import MutableSet, OrderedDict
 from six import assertCountEqual
 from six.moves import range
 
-from aodncore.pipeline import (CheckResult, PipelineFileCollection, PipelineFile, PipelineFileCheckType,
-                               PipelineFilePublishType)
+from aodncore.pipeline.common import (CheckResult, PipelineFileCheckType,PipelineFilePublishType)
+from aodncore.pipeline.files import PipelineFileCollection, PipelineFile, ensure_pipelinefilecollection
 from aodncore.pipeline.exceptions import DuplicateUniqueAttributeError, DuplicatePipelineFileError, MissingFileError
 from aodncore.pipeline.steps import get_child_check_runner
 from aodncore.testlib import BaseTestCase, get_nonexistent_path, mock
@@ -14,6 +14,18 @@ from test_aodncore import TESTDATA_DIR
 
 BAD_NC = os.path.join(TESTDATA_DIR, 'bad.nc')
 GOOD_NC = os.path.join(TESTDATA_DIR, 'good.nc')
+
+
+class TestPipelineFiles(BaseTestCase):
+    def test_ensure_pipelinefilecollection(self):
+        collection_from_collection = ensure_pipelinefilecollection(PipelineFileCollection())
+        self.assertIsInstance(collection_from_collection, PipelineFileCollection)
+
+        collection_from_file = ensure_pipelinefilecollection(PipelineFile(GOOD_NC))
+        self.assertIsInstance(collection_from_file, PipelineFileCollection)
+
+        with self.assertRaises(TypeError):
+            _ = ensure_pipelinefilecollection('invalid_type')
 
 
 # noinspection PyAttributeOutsideInit

--- a/test_aodncore/util/test_misc.py
+++ b/test_aodncore/util/test_misc.py
@@ -8,8 +8,8 @@ import six
 from aodncore.testlib import BaseTestCase
 from aodncore.util import (format_exception, is_function, is_nonstring_iterable, matches_regexes,
                            merge_dicts, slice_sequence, str_to_list, validate_callable, validate_mandatory_elements,
-                           validate_membership, validate_nonstring_iterable, validate_type, CaptureStdIO,
-                           WriteOnceOrderedDict)
+                           validate_membership, validate_nonstring_iterable, validate_relative_path, validate_type,
+                           CaptureStdIO, WriteOnceOrderedDict)
 
 StringIO = six.StringIO
 
@@ -162,6 +162,15 @@ class TestUtilMisc(BaseTestCase):
 
         with self.assertRaises(TypeError):
             validate_nonstring_iterable('s')
+
+    def test_validate_relative_path(self):
+        with self.assertRaises(ValueError):
+            validate_relative_path('/absolute/path')
+
+        try:
+            validate_relative_path('relative/path')
+        except Exception as e:
+            raise AssertionError("unexpected exception raised. {e}".format(e=format_exception(e)))
 
     def test_format_exception(self):
         try:


### PR DESCRIPTION
Fixes: https://github.com/aodn/python-aodncore/issues/63 (for the associated backlog item)

This supports the setting of a custom path for the input file (as opposed to the files in the collection).

This enables this type of use case:

```python
class MyHandler(HandlerBase):
    def preprocess(self):
        self.input_file_archive_path = 'my/archive/path/I/calculated/at/runtime'
```