### PR TITLE
PipelineFileCollection enhancements

### DIFF
--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -8,8 +8,9 @@ import six
 from .common import (FileType, PipelineFilePublishType, PipelineFileCheckType, validate_addition_publishtype,
                      validate_checkresult, validate_checktype, validate_deletion_publishtype, validate_publishtype)
 from .exceptions import DuplicateUniqueAttributeError, DuplicatePipelineFileError, MissingFileError
+from .schema import validate_check_params
 from ..util import (IndexedSet, format_exception, get_file_checksum, iter_public_attributes, matches_regexes,
-                    slice_sequence, validate_bool, validate_callable, validate_dict, validate_mapping,
+                    slice_sequence, validate_bool, validate_callable, validate_mapping,
                     validate_nonstring_iterable, validate_regex, validate_relative_path_attr, validate_string,
                     validate_type)
 
@@ -522,7 +523,7 @@ class PipelineFileCollection(MutableSet):
         return result
 
     def difference(self, sequence):
-        return self.__s.difference(sequence)
+        return PipelineFileCollection(self.__s.difference(sequence))
 
     def issubset(self, sequence):
         return self.__s.issubset(sequence)
@@ -579,6 +580,18 @@ class PipelineFileCollection(MutableSet):
             attribute matching the given value
         """
         collection = PipelineFileCollection(f for f in self.__s if getattr(f, attribute) is value)
+        return collection
+
+    def filter_by_attribute_id_not(self, attribute, value):
+        """Return a new :py:class:`PipelineFileCollection` containing only elements where the id of the given attribute
+        is *not* the given id (i.e. refers to the same object)
+
+        :param attribute: attribute by which to filter :py:class:`PipelineFile` instances
+        :param value: attribute id to filter on
+        :return: :py:class:`PipelineFileCollection` containing only :py:class:`PipelineFile` instances with the given
+            attribute not matching the given value
+        """
+        collection = PipelineFileCollection(f for f in self.__s if getattr(f, attribute) is not value)
         return collection
 
     def filter_by_attribute_value(self, attribute, value):
@@ -718,19 +731,6 @@ class PipelineFileCollection(MutableSet):
             columns = []
         return columns, data
 
-    def set_check_types(self, check_params):
-        if check_params is None:
-            check_params = {}
-        validate_dict(check_params)
-        checks = check_params.get('checks', ())
-        for f in self.__s:
-            if f.is_deletion:
-                f.check_type = PipelineFileCheckType.NO_ACTION
-            elif checks and f.file_type is FileType.NETCDF:
-                f.check_type = PipelineFileCheckType.NC_COMPLIANCE_CHECK
-            else:
-                f.check_type = PipelineFileCheckType.FORMAT_CHECK
-
     def set_archive_paths(self, archive_path_function):
         """Set archive_path attributes for each file in the collection
 
@@ -744,6 +744,15 @@ class PipelineFileCollection(MutableSet):
                 candidate_path = archive_path_function(f.src_path)
                 self.validate_unique_attribute_value('archive_path', candidate_path)
                 f.archive_path = candidate_path
+
+    def set_check_types(self, check_type):
+        """Set check_type attributes for each file in the collection
+
+        :param check_type: :py:class:`PipefileFileCheckType` enum member
+        :return: None
+        """
+        validate_checktype(check_type)
+        self._set_attribute('check_type', check_type)
 
     def set_dest_paths(self, dest_path_function):
         """Set dest_path attributes for each file in the collection
@@ -769,6 +778,15 @@ class PipelineFileCollection(MutableSet):
         validate_bool(value)
         self._set_attribute(attribute, value)
 
+    def set_publish_types(self, publish_type):
+        """Set publish_type attributes for each file in the collection
+
+        :param publish_type: :py:class:`PipefileFilePublishType` enum member
+        :return: None
+        """
+        validate_publishtype(publish_type)
+        self._set_attribute('publish_type', publish_type)
+
     def set_string_attribute(self, attribute, value):
         """Set a string attribute for each file in the collection
 
@@ -788,7 +806,32 @@ class PipelineFileCollection(MutableSet):
         for f in self.__s:
             f.file_update_callback = file_update_callback
 
-    def set_default_publish_types(self, include_regexes, exclude_regexes, addition_type, deletion_type):
+    def set_check_types_from_params(self, check_params):
+        """Set check_type attribute for each file in the collection to the default value, based on the file type and
+        presence of compliance checker checks in the check parameters
+
+        :param check_params: :py:class:`dict`
+        :return:
+        """
+        if check_params is None:
+            check_params = {}
+        else:
+            validate_check_params(check_params)
+
+        checks = check_params.get('checks', ())
+
+        all_deletions = PipelineFileCollection(f for f in self.__s if f.is_deletion)
+        all_additions = PipelineFileCollection(self.__s.difference(all_deletions))
+        netcdf_additions = PipelineFileCollection(f for f in all_additions if f.file_type is FileType.NETCDF)
+        non_netcdf_additions = all_additions.difference(netcdf_additions)
+
+        netcdf_check_type = PipelineFileCheckType.NC_COMPLIANCE_CHECK if checks else PipelineFileCheckType.FORMAT_CHECK
+
+        all_deletions.set_check_types(PipelineFileCheckType.NO_ACTION)
+        netcdf_additions.set_check_types(netcdf_check_type)
+        non_netcdf_additions.set_check_types(PipelineFileCheckType.FORMAT_CHECK)
+
+    def set_publish_types_from_regexes(self, include_regexes, exclude_regexes, addition_type, deletion_type):
         """Set publish_type attribute for each file in the collection depending on whether it is considered "included"
         according to the regex parameters
 

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -462,6 +462,10 @@ class PipelineFileCollection(MutableSet):
     def __repr__(self):  # pragma: no cover
         return "PipelineFileCollection({repr})".format(repr=repr(list(self.__s)))
 
+    def _set_attribute(self, attribute, value):
+        for f in self.__s:
+            setattr(f, attribute, value)
+
     def add(self, pipeline_file, deletion=False, overwrite=False):
         """Add a file to the collection
 
@@ -763,9 +767,17 @@ class PipelineFileCollection(MutableSet):
         :return: None
         """
         validate_bool(value)
+        self._set_attribute(attribute, value)
 
-        for f in self.__s:
-            setattr(f, attribute, value)
+    def set_string_attribute(self, attribute, value):
+        """Set a string attribute for each file in the collection
+
+        :param attribute: attribute to set
+        :param value: value to set the attribute
+        :return: None
+        """
+        validate_string(value)
+        self._set_attribute(attribute, value)
 
     def set_file_update_callback(self, file_update_callback):
         """Set a callback function in each :py:class:`PipelineFile` in this collection

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -597,19 +597,18 @@ class HandlerBase(object):
         resolved_files = resolve_runner.run()
 
         resolved_files.set_file_update_callback(self._file_update_callback)
-        resolved_files.set_default_publish_types(self.include_regexes, self.exclude_regexes,
-                                                 self.default_addition_publish_type,
-                                                 self.default_deletion_publish_type)
+        resolved_files.set_publish_types_from_regexes(self.include_regexes, self.exclude_regexes,
+                                                      self.default_addition_publish_type,
+                                                      self.default_deletion_publish_type)
 
         self.file_collection.update(resolved_files)
 
     def _check(self):
         check_runner = get_check_runner(self.config, self.logger, self.check_params)
         self.logger.sysinfo("get_check_runner -> '{runner}'".format(runner=check_runner.__class__.__name__))
-        self.file_collection.set_check_types(self.check_params)
-        files_to_check = PipelineFileCollection(
-            f for f in self.file_collection if f.check_type is not PipelineFileCheckType.NO_ACTION)
+        self.file_collection.set_check_types_from_params(self.check_params)
 
+        files_to_check = self.file_collection.filter_by_attribute_id_not('check_type', PipelineFileCheckType.NO_ACTION)
         if files_to_check:
             check_runner.run(files_to_check)
 

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -688,3 +688,57 @@ class TestPipelineFileCollection(BaseTestCase):
         table_headers, table_data = self.collection.get_table_data()
         self.assertListEqual([], table_headers)
         self.assertListEqual([], table_data)
+
+    @mock.patch("aodncore.pipeline.files.get_file_checksum")
+    @mock.patch("os.path.isfile")
+    def test_set_bool_attribute(self, mock_isfile, mock_get_file_checksum):
+        mock_isfile.return_value = True
+        mock_get_file_checksum.return_value = ''
+
+        f1 = get_nonexistent_path()
+        f2 = get_nonexistent_path()
+        f3 = get_nonexistent_path()
+        fileobj1 = PipelineFile(f1)
+        fileobj2 = PipelineFile(f2, is_deletion=True)
+        fileobj3 = PipelineFile(f3)
+        self.collection.update((fileobj1, fileobj2, fileobj3))
+
+        with self.assertRaises(TypeError):
+            self.collection.set_bool_attribute('is_harvested', 'not_a_bool')
+        with self.assertRaises(TypeError):
+            self.collection.set_bool_attribute('is_harvested', 1)
+        with self.assertRaises(TypeError):
+            self.collection.set_bool_attribute('is_harvested', [])
+
+        try:
+            self.collection.set_bool_attribute('is_harvested', True)
+        except Exception as e:
+            raise AssertionError(
+                "unexpected exception raised. {cls} {msg}".format(cls=e.__class__.__name__, msg=e))
+
+    @mock.patch("aodncore.pipeline.files.get_file_checksum")
+    @mock.patch("os.path.isfile")
+    def test_set_string_attribute(self, mock_isfile, mock_get_file_checksum):
+        mock_isfile.return_value = True
+        mock_get_file_checksum.return_value = ''
+
+        f1 = get_nonexistent_path()
+        f2 = get_nonexistent_path()
+        f3 = get_nonexistent_path()
+        fileobj1 = PipelineFile(f1)
+        fileobj2 = PipelineFile(f2, is_deletion=True)
+        fileobj3 = PipelineFile(f3)
+        self.collection.update((fileobj1, fileobj2, fileobj3))
+
+        with self.assertRaises(TypeError):
+            self.collection.set_string_attribute('dest_path', True)
+        with self.assertRaises(TypeError):
+            self.collection.set_string_attribute('archive_path', 1)
+        with self.assertRaises(TypeError):
+            self.collection.set_string_attribute('dest_path', [])
+
+        try:
+            self.collection.set_string_attribute('dest_path', 'valid/string')
+        except Exception as e:
+            raise AssertionError(
+                "unexpected exception raised. {cls} {msg}".format(cls=e.__class__.__name__, msg=e))

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -5,9 +5,9 @@ from collections import MutableSet, OrderedDict
 from six import assertCountEqual
 from six.moves import range
 
-from aodncore.pipeline.common import (CheckResult, PipelineFileCheckType,PipelineFilePublishType)
-from aodncore.pipeline.files import PipelineFileCollection, PipelineFile, ensure_pipelinefilecollection
+from aodncore.pipeline.common import (CheckResult, PipelineFileCheckType, PipelineFilePublishType)
 from aodncore.pipeline.exceptions import DuplicateUniqueAttributeError, DuplicatePipelineFileError, MissingFileError
+from aodncore.pipeline.files import PipelineFileCollection, PipelineFile, ensure_pipelinefilecollection
 from aodncore.pipeline.steps import get_child_check_runner
 from aodncore.testlib import BaseTestCase, get_nonexistent_path, mock
 from test_aodncore import TESTDATA_DIR
@@ -135,6 +135,19 @@ class TestPipelineFile(BaseTestCase):
         self.pipelinefile.is_harvested = True
         self.assertTrue(self.pipelinefile.is_harvested)
 
+    def test_property_is_overwrite(self):
+        self.assertFalse(self.pipelinefile.is_overwrite)
+        self.pipelinefile.is_overwrite = True
+        self.assertTrue(self.pipelinefile.is_overwrite)
+
+    def test_property_mime_type(self):
+        expected_default_value = 'application/octet-stream'
+        expected_value = 'application/xml'
+
+        self.assertEqual(self.pipelinefile.mime_type, expected_default_value)
+        self.pipelinefile.mime_type = expected_value
+        self.assertEqual(self.pipelinefile.mime_type, expected_value)
+
     def test_property_published_upload_only(self):
         self.pipelinefile.publish_type = PipelineFilePublishType.UPLOAD_ONLY
         self.assertEqual('No', self.pipelinefile.published)
@@ -160,6 +173,14 @@ class TestPipelineFile(BaseTestCase):
         self.assertEqual('Yes', self.pipelinefile.published)
         self.pipelinefile.is_upload_undone = True
         self.assertEqual('No', self.pipelinefile.published)
+
+    def test_property_should_undo(self):
+        self.assertFalse(self.pipelinefile.should_undo)
+        self.pipelinefile.should_undo = True
+        self.assertTrue(self.pipelinefile.should_undo)
+
+        with self.assertRaises(ValueError):
+            self.pipelinefile_deletion.should_undo = True
 
     def test_file_callback(self):
         class TestCallbackContainer(object):
@@ -305,7 +326,7 @@ class TestPipelineFileCollection(BaseTestCase):
         self.collection.add(p1)
 
         with self.assertRaises(DuplicateUniqueAttributeError):
-            self.collection.validate_unique_attribute_value('dest_path','FIXED_DEST_PATH')
+            self.collection.validate_unique_attribute_value('dest_path', 'FIXED_DEST_PATH')
 
         try:
             self.collection.validate_unique_attribute_value('dest_path', 'A_DIFFERENT_DEST_PATH')
@@ -516,6 +537,22 @@ class TestPipelineFileCollection(BaseTestCase):
                                                                      PipelineFilePublishType.DELETE_UNHARVEST)
         assertCountEqual(self, self.collection, filtered_collection)
 
+    def test_filter_by_attribute_id_not(self):
+        f1 = get_nonexistent_path()
+        f2 = get_nonexistent_path()
+        f3 = get_nonexistent_path()
+        fileobj1 = PipelineFile(f1, is_deletion=True)
+        fileobj1.publish_type = PipelineFilePublishType.DELETE_ONLY
+        fileobj2 = PipelineFile(f2, is_deletion=True)
+        fileobj2.publish_type = PipelineFilePublishType.DELETE_UNHARVEST
+        fileobj3 = PipelineFile(f3, is_deletion=True)
+        fileobj3.publish_type = PipelineFilePublishType.NO_ACTION
+        self.collection.update((fileobj1, fileobj2, fileobj3))
+
+        filtered_collection = self.collection.filter_by_attribute_id_not('publish_type',
+                                                                         PipelineFilePublishType.NO_ACTION)
+        assertCountEqual(self, filtered_collection, PipelineFileCollection((fileobj1, fileobj2)))
+
     def test_filter_by_attribute_value(self):
         f1 = get_nonexistent_path()
         fileobj1 = PipelineFile(f1, is_deletion=True)
@@ -554,6 +591,23 @@ class TestPipelineFileCollection(BaseTestCase):
 
         filtered_collection = self.collection.filter_by_bool_attribute('is_stored')
         self.assertSetEqual(filtered_collection, PipelineFileCollection())
+
+    @mock.patch("aodncore.pipeline.files.get_file_checksum")
+    @mock.patch("os.path.isfile")
+    def test_filter_by_bool_attribute_not(self, mock_isfile, mock_get_file_checksum):
+        mock_isfile.return_value = True
+        mock_get_file_checksum.return_value = ''
+
+        f1 = get_nonexistent_path()
+        f2 = get_nonexistent_path()
+        f3 = get_nonexistent_path()
+        fileobj1 = PipelineFile(f1)
+        fileobj2 = PipelineFile(f2, is_deletion=True)
+        fileobj3 = PipelineFile(f3)
+        self.collection.update((fileobj1, fileobj2, fileobj3))
+
+        filtered_collection = self.collection.filter_by_bool_attribute_not('is_deletion')
+        self.assertSetEqual(filtered_collection, PipelineFileCollection((fileobj1, fileobj3)))
 
     @mock.patch("aodncore.pipeline.files.get_file_checksum")
     @mock.patch("os.path.isfile")
@@ -715,6 +769,34 @@ class TestPipelineFileCollection(BaseTestCase):
         except Exception as e:
             raise AssertionError(
                 "unexpected exception raised. {cls} {msg}".format(cls=e.__class__.__name__, msg=e))
+
+    def test_set_check_types(self):
+        f1 = get_nonexistent_path()
+        f2 = get_nonexistent_path()
+        fileobj1 = PipelineFile(f1, is_deletion=True)
+        fileobj2 = PipelineFile(f2, is_deletion=True)
+        self.collection.update((fileobj1, fileobj2))
+
+        self.assertTrue(all(f.check_type is PipelineFileCheckType.NO_ACTION for f in self.collection))
+        self.collection.set_check_types(PipelineFileCheckType.NONEMPTY_CHECK)
+        self.assertTrue(all(f.check_type is PipelineFileCheckType.NONEMPTY_CHECK for f in self.collection))
+
+        with self.assertRaises(ValueError):
+            self.collection.set_check_types('invalid_type')
+
+    def test_set_publish_types(self):
+        f1 = get_nonexistent_path()
+        f2 = get_nonexistent_path()
+        fileobj1 = PipelineFile(f1, is_deletion=True)
+        fileobj2 = PipelineFile(f2, is_deletion=True)
+        self.collection.update((fileobj1, fileobj2))
+
+        self.assertTrue(all(f.publish_type is PipelineFilePublishType.NO_ACTION for f in self.collection))
+        self.collection.set_publish_types(PipelineFilePublishType.DELETE_UNHARVEST)
+        self.assertTrue(all(f.publish_type is PipelineFilePublishType.DELETE_UNHARVEST for f in self.collection))
+
+        with self.assertRaises(ValueError):
+            self.collection.set_publish_types('invalid_type')
 
     @mock.patch("aodncore.pipeline.files.get_file_checksum")
     @mock.patch("os.path.isfile")


### PR DESCRIPTION
Makes it easier to manipulate/filter the collection in some useful ways. Primarily to avoid unnecessary "for" loops in child handlers which are a common source of bugs when trying to do basic things like set attributes on files.