### PR TITLE
Custom params

### DIFF
--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -17,8 +17,8 @@ from .schema import (validate_check_params, validate_custom_params, validate_har
                      validate_resolve_params)
 from .statequery import StateQuery
 from .steps import (get_check_runner, get_harvester_runner, get_notify_runner, get_resolve_runner, get_store_runner)
-from ..util import (discover_entry_points, format_exception, get_file_checksum, iter_public_attributes, merge_dicts,
-                    validate_relative_path_attr, TemporaryDirectory)
+from ..util import (discover_entry_points, ensure_writeonceordereddict, format_exception, get_file_checksum,
+                    iter_public_attributes, merge_dicts, validate_relative_path_attr, TemporaryDirectory)
 from ..version import __version__ as _aodncore_version
 
 __all__ = [
@@ -586,7 +586,7 @@ class HandlerBase(object):
         self._file_collection = PipelineFileCollection()
 
         self._init_logging()
-        self._validate_params()
+        self._validate_and_freeze_params()
         self._set_checksum()
         self._check_extension()
         self._set_path_functions()
@@ -846,17 +846,22 @@ class HandlerBase(object):
         self.logger.sysinfo(
             "get_path_function (archive) -> '{function}'".format(function=self._archive_path_function_name))
 
-    def _validate_params(self):
-        if self.check_params:
+    def _validate_and_freeze_params(self):
+        if self.check_params is not None:
             validate_check_params(self.check_params)
-        if self.custom_params:
+            self.check_params = ensure_writeonceordereddict(self.check_params)
+        if self.custom_params is not None:
             validate_custom_params(self.custom_params)
-        if self.harvest_params:
+            self.custom_params = ensure_writeonceordereddict(self.custom_params)
+        if self.harvest_params is not None:
             validate_harvest_params(self.harvest_params)
-        if self.notify_params:
+            self.harvest_params = ensure_writeonceordereddict(self.harvest_params)
+        if self.notify_params is not None:
             validate_notify_params(self.notify_params)
-        if self.resolve_params:
+            self.notify_params = ensure_writeonceordereddict(self.notify_params)
+        if self.resolve_params is not None:
             validate_resolve_params(self.resolve_params)
+            self.resolve_params = ensure_writeonceordereddict(self.resolve_params)
 
     #
     # process methods - to be overridden by child class as required

--- a/aodncore/pipeline/schema.py
+++ b/aodncore/pipeline/schema.py
@@ -6,6 +6,7 @@ import jsonschema
 
 __all__ = [
     'validate_check_params',
+    'validate_custom_params',
     'validate_harvest_params',
     'validate_logging_config',
     'validate_pipeline_config',
@@ -22,6 +23,10 @@ CHECK_PARAMS_SCHEMA = {
         'verbosity': {'type': 'integer'}
     },
     'additionalProperties': False
+}
+
+CUSTOM_PARAMS_SCHEMA = {
+    'type': 'object'
 }
 
 HARVEST_PARAMS_SCHEMA = {
@@ -171,6 +176,10 @@ RESOLVE_PARAMS_SCHEMA = {
 
 def validate_check_params(check_params):
     jsonschema.validate(check_params, CHECK_PARAMS_SCHEMA)
+
+
+def validate_custom_params(check_params):
+    jsonschema.validate(check_params, CUSTOM_PARAMS_SCHEMA)
 
 
 def validate_harvest_params(harvest_params):

--- a/aodncore/util/__init__.py
+++ b/aodncore/util/__init__.py
@@ -3,11 +3,11 @@ from .fileops import (TemporaryDirectory, extract_zip, get_file_checksum, is_dir
                       list_regular_files, mkdir_p, rm_f, rm_r, rm_rf, safe_copy_file, safe_move_file,
                       validate_dir_writable, validate_file_writable)
 from .misc import (CaptureStdIO, LoggingContext, TemplateRenderer, WriteOnceOrderedDict, discover_entry_points,
-                   format_exception, is_function, is_nonstring_iterable, is_valid_email_address, iter_public_attributes,
-                   matches_regexes, merge_dicts, slice_sequence, str_to_list, validate_bool, validate_callable,
-                   validate_dict, validate_int, validate_mapping, validate_mandatory_elements, validate_membership,
-                   validate_nonstring_iterable, validate_regex, validate_relative_path, validate_relative_path_attr,
-                   validate_string, validate_type)
+                   ensure_writeonceordereddict, format_exception, is_function, is_nonstring_iterable,
+                   is_valid_email_address, iter_public_attributes, matches_regexes, merge_dicts, slice_sequence,
+                   str_to_list, validate_bool, validate_callable, validate_dict, validate_int, validate_mapping,
+                   validate_mandatory_elements, validate_membership, validate_nonstring_iterable, validate_regex,
+                   validate_relative_path, validate_relative_path_attr, validate_string, validate_type)
 from .process import SystemProcess
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     'classproperty',
     'extract_zip',
     'discover_entry_points',
+    'ensure_writeonceordereddict',
     'format_exception',
     'get_file_checksum',
     'is_dir_writable',

--- a/aodncore/util/misc.py
+++ b/aodncore/util/misc.py
@@ -19,6 +19,7 @@ StringIO = six.StringIO
 
 __all__ = [
     'discover_entry_points',
+    'ensure_writeonceordereddict',
     'format_exception',
     'is_nonstring_iterable',
     'is_function',
@@ -62,6 +63,27 @@ def discover_entry_points(entry_point_group, working_set=pkg_resources.working_s
         entry_point_object = entry_point.load()
         entry_points[entry_point.name] = entry_point_object
     return entry_points
+
+
+def ensure_writeonceordereddict(o, empty_on_fail=True):
+    """Function to accept and object and return the WriteOnceOrderedDict representation of the object. An object which
+    can *not* be handled by the WriteOnceOrderedDict __init__ method will either result in an empty, or if
+    'empty_on_fail' is set to False, will result in an exception.
+
+    :param o: input object
+    :param empty_on_fail: boolean flag to determine whether an invalid object will result in a new empty
+        WriteOnceOrderedDict being returned or the exception re-raised.
+    :return: :py:class:`WriteOnceOrderedDict` instance
+    """
+    if isinstance(o, WriteOnceOrderedDict):
+        return o
+
+    try:
+        return WriteOnceOrderedDict(o)
+    except (TypeError, ValueError):
+        if empty_on_fail:
+            return WriteOnceOrderedDict()
+        raise
 
 
 def format_exception(exception):

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -10,6 +10,7 @@ from aodncore.pipeline.exceptions import (ComplianceCheckFailedError, HandlerAlr
 from aodncore.pipeline.statequery import StateQuery
 from aodncore.pipeline.steps import NotifyList
 from aodncore.testlib import DummyHandler, HandlerTestCase, dest_path_testing, get_nonexistent_path, mock
+from aodncore.util import WriteOnceOrderedDict
 from test_aodncore import TESTDATA_DIR
 
 BAD_NC = os.path.join(TESTDATA_DIR, 'bad.nc')
@@ -53,6 +54,20 @@ class TestDummyHandler(HandlerTestCase):
         self.assertIn('good.nc', eligible_filenames)
         self.assertNotIn('bad.nc', eligible_filenames)
 
+    def test_params_freeze(self):
+        handler = self.run_handler(GOOD_NC,
+                                   check_params={},
+                                   custom_params={},
+                                   harvest_params={},
+                                   notify_params={},
+                                   resolve_params={})
+
+        self.assertIsInstance(handler.check_params, WriteOnceOrderedDict)
+        self.assertIsInstance(handler.custom_params, WriteOnceOrderedDict)
+        self.assertIsInstance(handler.harvest_params, WriteOnceOrderedDict)
+        self.assertIsInstance(handler.notify_params, WriteOnceOrderedDict)
+        self.assertIsInstance(handler.resolve_params, WriteOnceOrderedDict)
+
     def test_custom_params(self):
         custom_params = {
             'my_bool_param': False,
@@ -63,8 +78,8 @@ class TestDummyHandler(HandlerTestCase):
 
         }
 
-        handler = self.run_handler(BAD_ZIP, custom_params=custom_params)
-        self.assertIs(handler.custom_params, custom_params)
+        handler = self.run_handler(GOOD_NC, custom_params=custom_params)
+        self.assertDictEqual(handler.custom_params, custom_params)
 
     def test_invalid_handler_params(self):
         with self.assertRaises(TypeError):

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -53,6 +53,23 @@ class TestDummyHandler(HandlerTestCase):
         self.assertIn('good.nc', eligible_filenames)
         self.assertNotIn('bad.nc', eligible_filenames)
 
+    def test_custom_params(self):
+        custom_params = {
+            'my_bool_param': False,
+            'my_dict_param': {'key': 'value'},
+            'my_int_param': 1,
+            'my_list_param': [1],
+            'my_string_param': 'str'
+
+        }
+
+        handler = self.run_handler(BAD_ZIP, custom_params=custom_params)
+        self.assertIs(handler.custom_params, custom_params)
+
+    def test_invalid_handler_params(self):
+        with self.assertRaises(TypeError):
+            _ = self.handler_class(GOOD_NC, invalid_unknown_keyword_argument=1)
+
     def test_invalid_include_regex(self):
         self.run_handler_with_exception(ValueError, GOOD_NC, include_regexes=['['])
 
@@ -62,6 +79,9 @@ class TestDummyHandler(HandlerTestCase):
     def test_invalid_check_params(self):
         self.run_handler_with_exception(ValidationError, GOOD_NC, check_params={'invalid_param': 'value'})
         self.run_handler_with_exception(ValidationError, GOOD_NC, check_params={'checks': 'invalid_type'})
+
+    def test_invalid_custom_params(self):
+        self.run_handler_with_exception(ValidationError, GOOD_NC, custom_params='invalid_type')
 
     def test_invalid_harvest_params(self):
         self.run_handler_with_exception(ValidationError, GOOD_NC, harvest_params={'slice_size': 'twenty'})

--- a/test_aodncore/util/test_misc.py
+++ b/test_aodncore/util/test_misc.py
@@ -6,10 +6,11 @@ from collections import OrderedDict
 import six
 
 from aodncore.testlib import BaseTestCase
-from aodncore.util import (format_exception, is_function, is_nonstring_iterable, matches_regexes,
-                           merge_dicts, slice_sequence, str_to_list, validate_callable, validate_mandatory_elements,
-                           validate_membership, validate_nonstring_iterable, validate_relative_path,
-                           validate_relative_path_attr, validate_type, CaptureStdIO, WriteOnceOrderedDict)
+from aodncore.util import (ensure_writeonceordereddict, format_exception, is_function, is_nonstring_iterable,
+                           matches_regexes, merge_dicts, slice_sequence, str_to_list, validate_callable,
+                           validate_mandatory_elements, validate_membership, validate_nonstring_iterable,
+                           validate_relative_path, validate_relative_path_attr, validate_type, CaptureStdIO,
+                           WriteOnceOrderedDict)
 
 StringIO = six.StringIO
 
@@ -81,6 +82,35 @@ class TestWriteOnceOrderedDict(BaseTestCase):
 
 
 class TestUtilMisc(BaseTestCase):
+    def test_ensure_writeonceordereddict(self):
+        test_wood = WriteOnceOrderedDict({'key': 'value'})
+        ensured_wood = ensure_writeonceordereddict(test_wood)
+        self.assertIsInstance(ensured_wood, WriteOnceOrderedDict)
+        self.assertIs(ensured_wood, test_wood)
+
+        test_dict = {'key': 'value'}
+        ensured_dict = ensure_writeonceordereddict(test_dict)
+        self.assertIsInstance(ensured_dict, WriteOnceOrderedDict)
+        self.assertDictEqual(ensured_dict, test_dict)
+
+        test_invalid = 'str'
+        ensured_invalid = ensure_writeonceordereddict(test_invalid)
+        self.assertIsInstance(ensured_invalid, WriteOnceOrderedDict)
+        self.assertEqual(len(ensured_invalid), 0)
+
+        test_none = None
+        ensured_none = ensure_writeonceordereddict(test_none)
+        self.assertIsInstance(ensured_none, WriteOnceOrderedDict)
+        self.assertEqual(len(ensured_none), 0)
+
+        test_none_fail = None
+        with self.assertRaises(TypeError):
+            _ = ensure_writeonceordereddict(test_none_fail, empty_on_fail=False)
+
+        test_string_fail = 'str'
+        with self.assertRaises(ValueError):
+            _ = ensure_writeonceordereddict(test_string_fail, empty_on_fail=False)
+
     def test_is_function(self):
         class DummyClass(object):
             def dummy_method(self):


### PR DESCRIPTION
Replace **kwargs with custom_params to make handler parameters more strict.

This will prevent the following issue https://github.com/aodn/chef-private/pull/2813/files, where a parameter changed name, but the old name still being accepted and ignored (which was not the expectation!).

This also freezes the params so they can't be corrupted, as happened here: https://github.com/aodn/python-aodncore/commit/bea2fa59a30bb8d61cf19a177a901cbd5b088883#diff-874a2f1726acecf44483414552b613b5