### PR TITLE
add option to parse an attribute as a timestamp in FileClassifier

### DIFF
--- a/aodncore/pipeline/fileclassifier.py
+++ b/aodncore/pipeline/fileclassifier.py
@@ -24,6 +24,8 @@ Expected use::
 import os
 import re
 
+from datetime import datetime
+
 from netCDF4 import Dataset
 
 from .exceptions import InvalidFileFormatError, InvalidFileNameError, InvalidFileContentError
@@ -70,11 +72,14 @@ class FileClassifier(object):
             raise InvalidFileFormatError("Could not open NetCDF file '{path}'.".format(path=file_path))
 
     @classmethod
-    def _get_nc_att(cls, file_path, att_name, default=None):
-        """Return the value of a global attribute from a NetCDF file. If a
-        list of attribute names is given, a list of values is
-        returned.  Unless a default value other than None is given, a
-        missing attribute raises an exception.
+    def _get_nc_att(cls, file_path, att_name, default=None, time_format=None):
+        """Return the value of a global attribute from a NetCDF file. If a list of attribute
+        names is given, a list of values is returned. Unless a default value other than None
+        is given, a missing attribute raises an exception.
+
+        If time_format is not None, the value of the attribute is converted into a datetime
+        object using the given format. If this fails an error is raised. If time_format=True,
+        use the format required by the IMOS conventions.
 
         """
         dataset = cls._open_nc_file(file_path)
@@ -85,12 +90,29 @@ class FileClassifier(object):
             att_list = [att_name]
         values = []
 
+        if time_format is True:
+            time_format = '%Y-%m-%dT%H:%M:%SZ'
+
         for att in att_list:
-            val = getattr(dataset, att, default)
-            if val is None:
-                raise InvalidFileContentError(
-                    "File '{path}' has no attribute '{att}'".format(path=file_path, att=att)
-                )
+            if not hasattr(dataset, att):
+                if default is None:
+                    raise InvalidFileContentError(
+                        "File '{path}' has no attribute '{att}'".format(path=file_path, att=att)
+                    )
+                else:
+                    values.append(default)
+                    continue
+
+            val = getattr(dataset, att)
+            if time_format:
+                try:
+                    val = datetime.strptime(val, time_format)
+                except ValueError:
+                    raise InvalidFileContentError(
+                        "Could not parse attribute {att}='{val}' as a datetime"
+                        " (file '{file_path}')".format(att=att, val=val, file_path=file_path)
+                    )
+
             values.append(val)
         dataset.close()
 

--- a/test_aodncore/pipeline/test_fileclassifier.py
+++ b/test_aodncore/pipeline/test_fileclassifier.py
@@ -3,6 +3,8 @@
 
 import os
 import unittest
+
+from datetime import datetime
 from tempfile import mkstemp
 
 from aodncore.pipeline import FileClassifier
@@ -41,11 +43,18 @@ class TestFileClassifier(BaseTestCase):
         self.assertRaises(InvalidFileFormatError, FileClassifier._get_nc_att, self.testfile, 'attribute')
 
     def test_get_nc_att(self):
-        make_test_file(self.testfile, {'site_code': 'TEST1', 'title': 'Test file'})
+        make_test_file(self.testfile, {'site_code': 'TEST1',
+                                       'title': 'Test file',
+                                       'time_start': '2017-09-01T01:02:03Z'})
         self.assertEqual(FileClassifier._get_nc_att(self.testfile, 'site_code'), 'TEST1')
         self.assertEqual(FileClassifier._get_nc_att(self.testfile, 'missing', ''), '')
         self.assertEqual(FileClassifier._get_nc_att(self.testfile, ['site_code', 'title']),
-                         ['TEST1', 'Test file'])
+                         ['TEST1', 'Test file']
+                         )
+        self.assertEqual(FileClassifier._get_nc_att(self.testfile, 'time_start', time_format=True),
+                         datetime(2017, 9, 1, 1, 2, 3)
+                         )
+
         self.assertRaises(InvalidFileContentError, FileClassifier._get_nc_att, self.testfile, 'missing')
 
     def test_get_site_code(self):


### PR DESCRIPTION
This was done in data-services (https://github.com/aodn/data-services/pull/740/commits/94c5563115cd063a54221fff0794be8e901567be) after we moved FileClassifier into aodncore.

It is needed for ABOS_SOTS pipeline2.