### PR TITLE
Add ablility to validate dest_path/archive_path before the handler performs any destructive actions

### DIFF
--- a/aodncore/pipeline/exceptions.py
+++ b/aodncore/pipeline/exceptions.py
@@ -7,8 +7,8 @@ __all__ = [
     'PipelineProcessingError',
     'PipelineSystemError',
     'ComplianceCheckFailedError',
-    'DuplicateUniqueAttributeError',
     'AttributeNotSetError',
+    'AttributeValidationError',
     'DuplicatePipelineFileError',
     'HandlerAlreadyRunError',
     'InvalidCheckSuiteError',
@@ -54,10 +54,6 @@ class ComplianceCheckFailedError(PipelineProcessingError):
     pass
 
 
-class DuplicateUniqueAttributeError(PipelineProcessingError):
-    pass
-
-
 class InvalidFileNameError(PipelineProcessingError):
     pass
 
@@ -73,6 +69,10 @@ class InvalidFileFormatError(PipelineProcessingError):
 # System errors
 
 class AttributeNotSetError(PipelineSystemError):
+    pass
+
+
+class AttributeValidationError(PipelineSystemError):
     pass
 
 

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -7,7 +7,7 @@ import six
 
 from .common import (FileType, PipelineFilePublishType, PipelineFileCheckType, validate_addition_publishtype,
                      validate_checkresult, validate_checktype, validate_deletion_publishtype, validate_publishtype)
-from .exceptions import DuplicateUniqueAttributeError, DuplicatePipelineFileError, MissingFileError
+from .exceptions import AttributeValidationError, DuplicatePipelineFileError, MissingFileError
 from .schema import validate_check_params
 from ..util import (IndexedSet, format_exception, get_file_checksum, iter_public_attributes, matches_regexes,
                     slice_sequence, validate_bool, validate_callable, validate_mapping,
@@ -866,7 +866,7 @@ class PipelineFileCollection(MutableSet):
         """
         duplicates = [f for f in self.__s if getattr(f, attribute) == value]
         if duplicates:
-            raise DuplicateUniqueAttributeError(
+            raise AttributeValidationError(
                 "{attribute} value '{value}' already set for file(s) '{duplicates}'".format(attribute=attribute,
                                                                                             value=value,
                                                                                             duplicates=duplicates))
@@ -887,7 +887,7 @@ class PipelineFileCollection(MutableSet):
             duplicates = []
             for value in duplicate_values:
                 duplicates.extend(f for f in self.__s if getattr(f, attribute) == value)
-            raise DuplicateUniqueAttributeError(
+            raise AttributeValidationError(
                 "duplicate paths found for files '{duplicates}'".format(duplicates=duplicates))
 
 

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -871,6 +871,20 @@ class PipelineFileCollection(MutableSet):
                                                                                             value=value,
                                                                                             duplicates=duplicates))
 
+    def validate_attribute_value_matches_regexes(self, attribute, include_regexes):
+        """Check that the given :py:class:`PipelineFile` attribute matches at least one of the given regexes
+
+        :param attribute: the attribute to compare
+        :param include_regexes: list of regexes of which the attribute must match at least one
+        :return: None
+        """
+        unmatched = [f for f in self.__s if
+                     not matches_regexes(getattr(f, attribute), include_regexes=include_regexes)]
+        if unmatched:
+            raise AttributeValidationError(
+                "invalid attribute values found for files: {unmatched}. Must match one of: {regexes}".format(
+                    unmatched=unmatched, regexes=include_regexes))
+
     def validate_attribute_uniqueness(self, attribute):
         """Check that the given :py:class:`PipelineFile` attribute is unique amongst all :py:class:`PipelineFile`
         instances currently in the collection, and raise an exception if any duplicates are found

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -872,18 +872,20 @@ class PipelineFileCollection(MutableSet):
                                                                                             duplicates=duplicates))
 
     def validate_attribute_value_matches_regexes(self, attribute, include_regexes):
-        """Check that the given :py:class:`PipelineFile` attribute matches at least one of the given regexes
+        """Check that the given :py:class:`PipelineFile` attribute matches at least one of the given regexes for each
+        file in the collection and raise an exception if any have a non-matched value
 
         :param attribute: the attribute to compare
         :param include_regexes: list of regexes of which the attribute must match at least one
         :return: None
         """
-        unmatched = [f for f in self.__s if
-                     not matches_regexes(getattr(f, attribute), include_regexes=include_regexes)]
+        unmatched = {f.name: getattr(f, attribute)
+                     for f in self.__s
+                     if not matches_regexes(getattr(f, attribute), include_regexes=include_regexes)}
         if unmatched:
             raise AttributeValidationError(
-                "invalid attribute values found for files: {unmatched}. Must match one of: {regexes}".format(
-                    unmatched=unmatched, regexes=include_regexes))
+                "invalid '{attribute}' values found for files: {unmatched}. Must match one of: {regexes}".format(
+                    attribute=attribute, unmatched=unmatched, regexes=include_regexes))
 
     def validate_attribute_uniqueness(self, attribute):
         """Check that the given :py:class:`PipelineFile` attribute is unique amongst all :py:class:`PipelineFile`

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -683,14 +683,15 @@ class HandlerBase(object):
         self.file_collection.validate_attribute_uniqueness('archive_path')
 
         if self.allowed_archive_path_regexes:
-            self.file_collection.validate_attribute_value_matches_regexes('archive_path',
-                                                                          self.allowed_archive_path_regexes)
+            files_to_archive = self.file_collection.filter_by_bool_attribute('pending_archive')
+            files_to_archive.validate_attribute_value_matches_regexes('archive_path', self.allowed_archive_path_regexes)
 
         self.file_collection.set_dest_paths(self._dest_path_function_ref)
         self.file_collection.validate_attribute_uniqueness('dest_path')
 
         if self.allowed_dest_path_regexes:
-            self.file_collection.validate_attribute_value_matches_regexes('dest_path', self.allowed_dest_path_regexes)
+            files_to_store = self.file_collection.filter_by_bool_attributes_or('pending_store', 'pending_harvest')
+            files_to_store.validate_attribute_value_matches_regexes('dest_path', self.allowed_dest_path_regexes)
 
         self._upload_runner.set_is_overwrite(self.file_collection)
 

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -5,9 +5,9 @@ import unittest
 from jsonschema import ValidationError
 
 from aodncore.pipeline import PipelineFilePublishType, HandlerResult
-from aodncore.pipeline.exceptions import (ComplianceCheckFailedError, HandlerAlreadyRunError, InvalidCheckSuiteError,
-                                          InvalidInputFileError, InvalidFileFormatError, InvalidRecipientError,
-                                          UnmatchedFilesError)
+from aodncore.pipeline.exceptions import (AttributeValidationError, ComplianceCheckFailedError, HandlerAlreadyRunError,
+                                          InvalidCheckSuiteError, InvalidInputFileError, InvalidFileFormatError,
+                                          InvalidRecipientError, UnmatchedFilesError)
 from aodncore.pipeline.statequery import StateQuery
 from aodncore.pipeline.steps import NotifyList
 from aodncore.testlib import DummyHandler, HandlerTestCase, dest_path_testing, get_nonexistent_path, mock
@@ -153,6 +153,13 @@ class TestDummyHandler(HandlerTestCase):
                                  "input file '.*' does not match any patterns in the allowed_regexes list:.*")
 
         self.run_handler(self.temp_nc_file, dest_path_function=dest_path_testing, allowed_regexes=['.*\.nc'])
+
+    def test_allowed_dest_path_regexes(self):
+        self.run_handler_with_exception(AttributeValidationError, self.temp_nc_file,
+                                        dest_path_function=dest_path_testing,
+                                        allowed_dest_path_regexes=['DEFINITELY/NOT/A/MATCH'])
+
+        self.run_handler(self.temp_nc_file, dest_path_function=dest_path_testing, allowed_dest_path_regexes=['DUMMY.*'])
 
     def test_allowed_extensions_and_allowed_regexes(self):
         self.run_handler_with_exception(InvalidInputFileError, GOOD_NC, dest_path_function=dest_path_testing,

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -6,7 +6,7 @@ from six import assertCountEqual
 from six.moves import range
 
 from aodncore.pipeline.common import (CheckResult, PipelineFileCheckType, PipelineFilePublishType)
-from aodncore.pipeline.exceptions import DuplicateUniqueAttributeError, DuplicatePipelineFileError, MissingFileError
+from aodncore.pipeline.exceptions import AttributeValidationError, DuplicatePipelineFileError, MissingFileError
 from aodncore.pipeline.files import PipelineFileCollection, PipelineFile, ensure_pipelinefilecollection
 from aodncore.pipeline.steps import get_child_check_runner
 from aodncore.testlib import BaseTestCase, get_nonexistent_path, mock
@@ -283,7 +283,7 @@ class TestPipelineFileCollection(BaseTestCase):
         p2.publish_type = PipelineFilePublishType.UPLOAD_ONLY
         p2.dest_path = 'FIXED_DEST_PATH'
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.add(p2)
 
     def test_add_duplicate_archive_path(self):
@@ -296,7 +296,7 @@ class TestPipelineFileCollection(BaseTestCase):
         p2.publish_type = PipelineFilePublishType.ARCHIVE_ONLY
         p2.archive_path = 'FIXED_ARCHIVE_PATH'
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.add(p2)
 
     def test_set_dest_paths_duplicate(self):
@@ -309,7 +309,7 @@ class TestPipelineFileCollection(BaseTestCase):
         p2.publish_type = PipelineFilePublishType.UPLOAD_ONLY
         self.collection.update((p1, p2))
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.set_dest_paths(dest_path_static)
 
     def test_set_archive_paths_duplicate(self):
@@ -322,7 +322,7 @@ class TestPipelineFileCollection(BaseTestCase):
         p2.publish_type = PipelineFilePublishType.ARCHIVE_ONLY
         self.collection.update((p1, p2))
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.set_archive_paths(archive_path_static)
 
     def test_validate_unique_attribute_value_dest_path(self):
@@ -331,7 +331,7 @@ class TestPipelineFileCollection(BaseTestCase):
         p1.dest_path = 'FIXED_DEST_PATH'
         self.collection.add(p1)
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.validate_unique_attribute_value('dest_path', 'FIXED_DEST_PATH')
 
         try:
@@ -346,7 +346,7 @@ class TestPipelineFileCollection(BaseTestCase):
         p1.archive_path = 'FIXED_ARCHIVE_PATH'
         self.collection.add(p1)
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.validate_unique_attribute_value('archive_path', 'FIXED_ARCHIVE_PATH')
 
         try:
@@ -369,7 +369,7 @@ class TestPipelineFileCollection(BaseTestCase):
         # edge case where the path is updated in a way that the collection cannot be aware of it
         p2.dest_path = 'FIXED_DEST_PATH'
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.validate_attribute_uniqueness('dest_path')
 
     def test_validate_attribute_uniqueness_archive_path(self):
@@ -386,7 +386,7 @@ class TestPipelineFileCollection(BaseTestCase):
         # edge case where the path is updated in a way that the collection cannot be aware of it
         p2.archive_path = 'FIXED_ARCHIVE_PATH'
 
-        with self.assertRaises(DuplicateUniqueAttributeError):
+        with self.assertRaises(AttributeValidationError):
             self.collection.validate_attribute_uniqueness('archive_path')
 
     def test_invalid_types(self):

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -325,6 +325,27 @@ class TestPipelineFileCollection(BaseTestCase):
         with self.assertRaises(AttributeValidationError):
             self.collection.set_archive_paths(archive_path_static)
 
+    def test_validate_attribute_value_matches_regexes(self):
+        allowed_regexes = ['^VALID/PREFIX.*$']
+        p1 = PipelineFile(GOOD_NC)
+        p1.dest_path = 'VALID/PREFIX/TO/TEST'
+        self.collection.add(p1)
+
+        try:
+            self.collection.validate_attribute_value_matches_regexes('dest_path', allowed_regexes)
+        except Exception as e:
+            raise AssertionError(
+                "unexpected exception raised. {cls} {msg}".format(cls=e.__class__.__name__, msg=e))
+
+    def test_validate_attribute_value_matches_regexes_failure(self):
+        allowed_regexes = ['^VALID/PREFIX.*$']
+        p1 = PipelineFile(GOOD_NC)
+        p1.dest_path = 'INVALID/PREFIX/TO/TEST'
+        self.collection.add(p1)
+
+        with self.assertRaises(AttributeValidationError):
+            self.collection.validate_attribute_value_matches_regexes('dest_path', allowed_regexes)
+
     def test_validate_unique_attribute_value_dest_path(self):
         p1 = PipelineFile(GOOD_NC)
         p1.publish_type = PipelineFilePublishType.UPLOAD_ONLY


### PR DESCRIPTION
Following on from: https://github.com/aodn/python-aodndata/pull/46

This allows handlers to be configured to exit with an error before publishing anything with an invalid dest_path, as determined by the handler parameters.

For example, Argo would be configured as follows:

```python
handler = ArgoHandler(input_file, allowed_dest_path_regexes=['IMOS/Argo'])
```

Then if, for any reason(e.g. a bug) manages to generate a dest_path outside of 'IMOS/Argo', the handler will error out before publishing anything (i.e. harvesters/uploads/deletions only happen if *every* file matches one of the given regexes).