### PR TITLE
Add skip_checks option to check_params

### DIFF
--- a/aodncore/pipeline/schema.py
+++ b/aodncore/pipeline/schema.py
@@ -19,6 +19,7 @@ CHECK_PARAMS_SCHEMA = {
     'properties': {
         'checks': {'type': 'array'},
         'criteria': {'type': 'string'},
+        'skip_checks': {'type': 'array', 'items': {'type': 'string'}},
         'output_format': {'type': 'string'},
         'verbosity': {'type': 'integer'}
     },

--- a/aodncore/pipeline/steps/check.py
+++ b/aodncore/pipeline/steps/check.py
@@ -116,6 +116,7 @@ class ComplianceCheckerCheckRunner(BaseCheckRunner):
         self.checks = check_params.get('checks', None)
         self.verbosity = check_params.get('verbosity', 0)
         self.criteria = check_params.get('criteria', 'normal')
+        self.skip_checks = check_params.get('skip_checks', None)
         self.output_format = check_params.get('output_format', 'text')
 
         if not self.checks:
@@ -132,6 +133,9 @@ class ComplianceCheckerCheckRunner(BaseCheckRunner):
                 'invalid compliance check suites: {invalid_suites}'.format(invalid_suites=invalid_suites))
 
     def run(self, pipeline_files):
+        if self.skip_checks:
+            self._logger.info("compliance checks will skip {skip_checks}".format(skip_checks=self.skip_checks))
+
         for pipeline_file in pipeline_files:
             self._logger.info(
                 "checking compliance of '{filepath}' against {checks}".format(filepath=pipeline_file.src_path,
@@ -166,7 +170,7 @@ class ComplianceCheckerCheckRunner(BaseCheckRunner):
         try:
             with CaptureStdIO() as (stdout_log, stderr_log):
                 compliant, errors = ComplianceChecker.run_checker(file_path, [check],
-                                                                  self.verbosity, self.criteria,
+                                                                  self.verbosity, self.criteria, self.skip_checks,
                                                                   output_format=self.output_format)
         except Exception as e:  # pragma: no cover
             errors = True

--- a/test_aodncore/pipeline/steps/test_check.py
+++ b/test_aodncore/pipeline/steps/test_check.py
@@ -12,6 +12,7 @@ from test_aodncore import TESTDATA_DIR
 BAD_NC = os.path.join(TESTDATA_DIR, 'bad.nc')
 EMPTY_NC = os.path.join(TESTDATA_DIR, 'empty.nc')
 GOOD_NC = os.path.join(TESTDATA_DIR, 'good.nc')
+WARNING_NC = os.path.join(TESTDATA_DIR, 'test_manifest.nc')
 
 
 class TestPipelineStepsCheck(BaseTestCase):
@@ -94,6 +95,18 @@ class TestComplianceCheckerRunner(BaseTestCase):
     def test_no_check_suite(self):
         with self.assertRaises(InvalidCheckSuiteError):
             self.cc_runner = ComplianceCheckerCheckRunner(None, self.test_logger)
+
+    def test_skip_checks(self):
+        collection = PipelineFileCollection([WARNING_NC])
+        self.cc_runner.run(collection)
+        self.assertFalse(collection[0].check_result.compliant)  # WARNING_NC file fails with just one warning
+
+        self.cc_runner = ComplianceCheckerCheckRunner(None,
+                                                      self.test_logger,
+                                                      {'checks': ['cf'], 'skip_checks': ['check_convention_globals']}
+                                                      )
+        self.cc_runner.run(collection)
+        self.assertTrue(collection[0].check_result.compliant)  # now should pass
 
 
 class TestFormatCheckRunner(BaseTestCase):


### PR DESCRIPTION
This is needed right now in order to allow skipping a few annoying checks in some pipelines.

It's related to #97, but is a smaller, simpler change that doesn't require updating all the existing watch configs.