### PR TITLE
Update LocalStorageBroker to return relative "keys" rather than absol…

### DIFF
--- a/aodncore/pipeline/storage.py
+++ b/aodncore/pipeline/storage.py
@@ -188,7 +188,8 @@ class LocalFileStorageBroker(BaseStorageBroker):
                     fullpath = os.path.join(root, name)
                     if fullpath.startswith(full_query) and not os.path.islink(fullpath):
                         stats = os.stat(fullpath)
-                        yield os.path.abspath(fullpath), {'last_modified': datetime.fromtimestamp(stats.st_mtime),
+                        key = os.path.relpath(fullpath, self.prefix)
+                        yield key, {'last_modified': datetime.fromtimestamp(stats.st_mtime),
                                                           'size': stats.st_size}
 
         result = dict(_find_prefix(full_query))

--- a/test_aodncore/pipeline/test_storage.py
+++ b/test_aodncore/pipeline/test_storage.py
@@ -1,9 +1,9 @@
+import datetime
 import errno
 import os
 import tempfile
 from uuid import uuid4
 
-import datetime
 from botocore.exceptions import ClientError
 from dateutil.tz import tzutc
 
@@ -301,7 +301,11 @@ class TestLocalFileStorageBroker(BaseTestCase):
             file_storage_broker = LocalFileStorageBroker(d)
             result = file_storage_broker.query('subdir/')
 
-        self.assertItemsEqual(result.keys(), [temp_file1, temp_file2, temp_file3])
+        self.assertItemsEqual(result.keys(), [
+            os.path.relpath(temp_file1, d),
+            os.path.relpath(temp_file2, d),
+            os.path.relpath(temp_file3, d)
+        ])
         self.assertTrue(all(isinstance(v['last_modified'], datetime.datetime) for k, v in result.items()))
         self.assertTrue(all(isinstance(v['size'], int) for k, v in result.items()))
 
@@ -317,7 +321,10 @@ class TestLocalFileStorageBroker(BaseTestCase):
             file_storage_broker = LocalFileStorageBroker(d)
             result = file_storage_broker.query('subdir/qwerty')
 
-        self.assertItemsEqual(result.keys(), [temp_file1, temp_file2])
+        self.assertItemsEqual(result.keys(), [
+            os.path.relpath(temp_file1, d),
+            os.path.relpath(temp_file2, d)
+        ])
         self.assertTrue(all(isinstance(v['last_modified'], datetime.datetime) for k, v in result.items()))
         self.assertTrue(all(isinstance(v['size'], int) for k, v in result.items()))
 


### PR DESCRIPTION
…ute paths (since this is supposed to be abstracted from the underlying implementation, and mimic S3)

Fixes https://github.com/aodn/python-aodncore/issues/114

@bpasquer @lbesnard @mhidas It's possible this could break some tests, but if it does, it means the tests were relying on incorrect behaviour and were not representative of real S3, so should be changed anyway!