### PR TITLE
Revert "Update LocalFileStorageBroker delete method to use os.remove,…

### DIFF
--- a/aodncore/pipeline/storage.py
+++ b/aodncore/pipeline/storage.py
@@ -15,8 +15,8 @@ except ImportError:
 
 from .exceptions import AttributeNotSetError, InvalidStoreUrlError, StorageBrokerError
 from .files import ensure_pipelinefilecollection, PipelineFile, PipelineFileCollection
-from ..util import (ensure_regex_list, format_exception, matches_regexes, mkdir_p, retry_decorator, safe_copy_file,
-                    validate_relative_path, validate_type)
+from ..util import (ensure_regex_list, format_exception, matches_regexes, mkdir_p, retry_decorator, rm_f,
+                    safe_copy_file, validate_relative_path, validate_type)
 
 __all__ = [
     'get_storage_broker',
@@ -202,7 +202,7 @@ class LocalFileStorageBroker(BaseStorageBroker):
 
     def _delete_file(self, pipeline_file, dest_path_attr):
         abs_path = self._get_absolute_dest_path(pipeline_file=pipeline_file, dest_path_attr=dest_path_attr)
-        os.remove(abs_path)
+        rm_f(abs_path)
 
     def _get_is_overwrite(self, pipeline_file, abs_path):
         return os.path.exists(abs_path)

--- a/test_aodncore/pipeline/test_storage.py
+++ b/test_aodncore/pipeline/test_storage.py
@@ -303,8 +303,8 @@ class TestLocalFileStorageBroker(BaseTestCase):
 
         self.assertTrue(netcdf_file.is_stored)
 
-    @mock.patch('aodncore.pipeline.storage.os.remove')
-    def test_delete_collection(self, mock_os_remove):
+    @mock.patch('aodncore.pipeline.storage.rm_f')
+    def test_delete_collection(self, mock_rm_f):
         collection = get_upload_collection(delete=True)
         netcdf_file, png_file, ico_file, unknown_file = collection
 
@@ -316,16 +316,16 @@ class TestLocalFileStorageBroker(BaseTestCase):
         ico_dest_path = os.path.join(file_storage_broker.prefix, ico_file.dest_path)
         unknown_dest_path = os.path.join(file_storage_broker.prefix, unknown_file.dest_path)
 
-        self.assertEqual(mock_os_remove.call_count, 4)
-        mock_os_remove.assert_any_call(netcdf_dest_path)
-        mock_os_remove.assert_any_call(png_dest_path)
-        mock_os_remove.assert_any_call(ico_dest_path)
-        mock_os_remove.assert_any_call(unknown_dest_path)
+        self.assertEqual(mock_rm_f.call_count, 4)
+        mock_rm_f.assert_any_call(netcdf_dest_path)
+        mock_rm_f.assert_any_call(png_dest_path)
+        mock_rm_f.assert_any_call(ico_dest_path)
+        mock_rm_f.assert_any_call(unknown_dest_path)
 
         self.assertTrue(all(p.is_stored for p in collection))
 
-    @mock.patch('aodncore.pipeline.storage.os.remove')
-    def test_delete_file(self, mock_os_remove):
+    @mock.patch('aodncore.pipeline.storage.rm_f')
+    def test_delete_file(self, mock_rm_f):
         collection = get_upload_collection(delete=True)
         netcdf_file, _, _, _ = collection
 
@@ -334,8 +334,8 @@ class TestLocalFileStorageBroker(BaseTestCase):
 
         netcdf_dest_path = os.path.join(file_storage_broker.prefix, netcdf_file.dest_path)
 
-        self.assertEqual(1, mock_os_remove.call_count)
-        mock_os_remove.assert_any_call(netcdf_dest_path)
+        self.assertEqual(1, mock_rm_f.call_count)
+        mock_rm_f.assert_any_call(netcdf_dest_path)
 
         self.assertTrue(netcdf_file.is_stored)
 


### PR DESCRIPTION
… since it should not silently succeed if the path doesn't exist"

This reverts commit 8fa448c5cf139c54e6f230f0f9f9838441140449.

Reverting this, as it causes behaviour to differ between S3 and local storage brokers. Subsequent decision required to choose which behaviour should be expected/implemented across *all* storage brokers (i.e. silently ignore deletion of nonexistent files, or cause this to be an error).