### PR TITLE
Filetype multiple extensions

### DIFF
--- a/aodncore/pipeline/common.py
+++ b/aodncore/pipeline/common.py
@@ -97,10 +97,13 @@ class FileType(Enum):
 
     Each enum member may have it's attributes accessed by name when required for comparisons and filtering, e.g.
 
-    - lookup the extension for PNG file types in general::
+    - lookup the extension and mime-type for PNG file types in general::
 
-        FileType.PNG.extension
-        '.png'
+        FileType.PNG.extensions
+        ('.png',)
+
+        FileType.PNG.mime_type
+        'image/png'
 
     - assign a type attribute to an object, and query the type-specific values directly from the object::
 
@@ -108,37 +111,37 @@ class FileType(Enum):
             pass
 
         o = Object()
-        o.file_type = FileType.ZIP
-        o.file_type.extension
-        '.zip'
+        o.file_type = FileType.JPEG
+        o.file_type.extensions
+        ('.jpg', '.jpeg')
         o.file_type.mime_type
-        'application/zip'
+        'image/jpeg'
     """
-    __slots__ = ('extension', 'mime_type')
+    __slots__ = ('extensions', 'mime_type')
 
     UNKNOWN = ()
 
-    CSV = ('.csv', 'text/csv')
-    GZIP = ('.gz', 'application/gzip')
-    JPEG = ('.jpg', 'image/jpeg')
-    PDF = ('.pdf', 'application/pdf')
-    PNG = ('.png', 'image/png')
-    ZIP = ('.zip', 'application/zip')
+    CSV = (('.csv',), 'text/csv')
+    GZIP = (('.gz',), 'application/gzip')
+    JPEG = (('.jpg', '.jpeg'), 'image/jpeg')
+    PDF = (('.pdf',), 'application/pdf')
+    PNG = (('.png',), 'image/png')
+    ZIP = (('.zip',), 'application/zip')
 
-    NETCDF = ('.nc', 'application/octet-stream')
-    DIR_MANIFEST = ('.dir_manifest', 'text/plain')
-    MAP_MANIFEST = ('.map_manifest', 'text/plain')
-    RSYNC_MANIFEST = ('.rsync_manifest', 'text/plain')
-    SIMPLE_MANIFEST = ('.manifest', 'text/plain')
+    NETCDF = (('.nc',), 'application/octet-stream')
+    DIR_MANIFEST = (('.dir_manifest',), 'text/plain')
+    MAP_MANIFEST = (('.map_manifest',), 'text/plain')
+    RSYNC_MANIFEST = (('.rsync_manifest',), 'text/plain')
+    SIMPLE_MANIFEST = (('.manifest',), 'text/plain')
 
-    def __init__(self, extension=None, mime_type=None):
-        self.extension = extension
+    def __init__(self, extensions=None, mime_type=None):
+        self.extensions = extensions
         self.mime_type = mime_type
 
     # noinspection PyTypeChecker
     @classmethod
     def get_type_from_extension(cls, extension):
-        return next((t for t in cls if t.extension == extension), cls.UNKNOWN)
+        return next((t for t in cls if t.extensions and extension.lower() in t.extensions), cls.UNKNOWN)
 
     @classmethod
     def get_type_from_name(cls, name):

--- a/aodncore/pipeline/steps/resolve.py
+++ b/aodncore/pipeline/steps/resolve.py
@@ -50,19 +50,19 @@ def get_resolve_runner(input_file, output_dir, config, logger, resolve_params=No
     :param resolve_params: dict of parameters to pass to :py:class:`BaseResolveRunner` class for runtime configuration
     :return: :py:class:`BaseResolveRunner` class
     """
-    _, file_extension = os.path.splitext(input_file)
+    file_type = FileType.get_type_from_name(input_file)
 
-    if file_extension == FileType.ZIP.extension:
+    if file_type is FileType.ZIP:
         return ZipFileResolveRunner(input_file, output_dir, config, logger)
-    elif file_extension == FileType.SIMPLE_MANIFEST.extension:
+    elif file_type is FileType.SIMPLE_MANIFEST:
         return SimpleManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
-    elif file_extension == FileType.MAP_MANIFEST.extension:
+    elif file_type is FileType.MAP_MANIFEST:
         return MapManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
-    elif file_extension == FileType.RSYNC_MANIFEST.extension:
+    elif file_type is FileType.RSYNC_MANIFEST:
         return RsyncManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
-    elif file_extension == FileType.DIR_MANIFEST.extension:
+    elif file_type is FileType.DIR_MANIFEST:
         return DirManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
-    elif file_extension == FileType.GZIP.extension:
+    elif file_type is FileType.GZIP:
         return GzipFileResolveRunner(input_file, output_dir, config, logger)
     else:
         return SingleFileResolveRunner(input_file, output_dir, config, logger)

--- a/aodncore/util/__init__.py
+++ b/aodncore/util/__init__.py
@@ -1,7 +1,7 @@
 from .external import retry_decorator, IndexedSet, classproperty
 from .fileops import (TemporaryDirectory, extract_gzip, extract_zip, get_file_checksum, is_dir_writable, is_gzipfile,
-                      is_netcdffile, is_zipfile, list_regular_files, mkdir_p, rm_f, rm_r, rm_rf, safe_copy_file,
-                      safe_move_file, validate_dir_writable, validate_file_writable)
+                      is_netcdffile, is_nonemptyfile, is_zipfile, list_regular_files, mkdir_p, rm_f, rm_r, rm_rf,
+                      safe_copy_file, safe_move_file, validate_dir_writable, validate_file_writable)
 from .misc import (CaptureStdIO, LoggingContext, TemplateRenderer, WriteOnceOrderedDict, discover_entry_points,
                    ensure_regex, ensure_regex_list, ensure_writeonceordereddict, format_exception,
                    get_pattern_subgroups_from_string, is_function, is_nonstring_iterable, is_valid_email_address,
@@ -32,6 +32,7 @@ __all__ = [
     'is_dir_writable',
     'is_gzipfile',
     'is_netcdffile',
+    'is_nonemptyfile',
     'is_zipfile',
     'is_function',
     'is_nonstring_iterable',

--- a/aodncore/util/fileops.py
+++ b/aodncore/util/fileops.py
@@ -33,6 +33,7 @@ __all__ = [
     'is_file_writable',
     'is_gzipfile',
     'is_netcdffile',
+    'is_nonemptyfile',
     'is_zipfile',
     'list_regular_files',
     'mkdir_p',
@@ -155,6 +156,20 @@ def is_file_writable(path):
     return os.access(path, os.W_OK)
 
 
+def is_gzipfile(filepath):
+    """Check whether a file path refers to a valid ZIP file
+
+    :param filepath: path to the file being checked
+    :return: True if filepath is a valid ZIP file, otherwise False
+    """
+    try:
+        with gzip.open(filepath) as g:
+            _ = g.read(1)
+        return True
+    except IOError:
+        return False
+
+
 def is_netcdffile(filepath):
     """Check whether a file path refers to a valid NetCDF file
 
@@ -173,18 +188,13 @@ def is_netcdffile(filepath):
             fh.close()
 
 
-def is_gzipfile(filepath):
-    """Check whether a file path refers to a valid ZIP file
+def is_nonemptyfile(filepath):
+    """Check whether a file path refers to a file with length greater than zero
 
     :param filepath: path to the file being checked
-    :return: True if filepath is a valid ZIP file, otherwise False
+    :return: True if filepath is non-zero, otherwise False
     """
-    try:
-        with gzip.open(filepath) as g:
-            _ = g.read(1)
-        return True
-    except IOError:
-        return False
+    return os.path.getsize(filepath) > 0
 
 
 def is_zipfile(filepath):

--- a/test_aodncore/pipeline/test_common.py
+++ b/test_aodncore/pipeline/test_common.py
@@ -1,0 +1,40 @@
+import uuid
+
+from aodncore.pipeline.common import FileType
+from aodncore.testlib import BaseTestCase
+
+
+class TestFileType(BaseTestCase):
+    def setUp(self):
+        super(TestFileType, self).setUp()
+
+    def test_get_type_from_extension_nc(self):
+        nc = FileType.get_type_from_extension('.nc')
+        self.assertIs(nc, FileType.NETCDF)
+
+        nc_upper = FileType.get_type_from_extension('.NC')
+        self.assertIs(nc_upper, FileType.NETCDF)
+
+    def test_get_type_from_extension_unknown(self):
+        random_extension = ".{}".format(str(uuid.uuid4()))
+        unknown_type = FileType.get_type_from_extension(random_extension)
+        self.assertIs(unknown_type, FileType.UNKNOWN)
+
+    def test_get_type_from_extension_jpeg(self):
+        jpg = FileType.get_type_from_extension('.jpg')
+        self.assertIs(jpg, FileType.JPEG)
+
+        jpeg = FileType.get_type_from_extension('.jpeg')
+        self.assertIs(jpeg, FileType.JPEG)
+
+        jpeg_upper = FileType.get_type_from_extension('.JPEG')
+        self.assertIs(jpeg_upper, FileType.JPEG)
+
+    def test_get_type_from_name_nc(self):
+        nc_type = FileType.get_type_from_name('file.nc')
+        self.assertIs(nc_type, FileType.NETCDF)
+
+    def test_get_type_from_name_unknown(self):
+        random_filename = "file.{}".format(str(uuid.uuid4()))
+        unknown_type = FileType.get_type_from_name(random_filename)
+        self.assertIs(unknown_type, FileType.UNKNOWN)


### PR DESCRIPTION
This allows multiple extensions to correspond with a single FileType enum member.

The primary change is that the "extension" attribute of the enum members has changed from a string to a tuple of valid extensions for a given type. Additionally, the comparison is now case-insensitive, which means for example jpg, jpeg, JPG and JPEG will all be interpreted as a `FileType.JPEG`.

Since this is no longer a one-to-one mapping between extension and type, it's no longer possible to return a single extension from a type, but a) I couldn't find any code doing this and b) if this is required for some reason, it could be a convention to use the *first* extension as a default or preferred option. Hard to envisage anything wanting to do this though, but is hypothetically possible.

I couldn't see anything in python-aodndata that should be affected by this, since comparisons such as `PipelineFile.file_type is FileType.JPEG` are unaffected, and that is the predominant use of this enum.