### PR TITLE
Fix HandlerBase.state_query lazy property

### DIFF
--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -582,10 +582,8 @@ class HandlerBase(object):
         :return: StateQuery instance
         :rtype: :py:class:`StateQuery`
         """
-        if self._state_query is None:
-            self._state_query = StateQuery(storage_broker=self._upload_store_runner.broker,
-                                           wfs_url=self.config.pipeline_config['global'].get('wfs_url'))
-        return self._state_query
+        return StateQuery(storage_broker=self._upload_store_runner.broker,
+                          wfs_url=self.config.pipeline_config['global'].get('wfs_url'))
 
     @property
     def default_addition_publish_type(self):

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -9,6 +9,7 @@ from aodncore.pipeline import PipelineFile, PipelineFileCheckType, PipelineFileP
 from aodncore.pipeline.exceptions import (AttributeValidationError, ComplianceCheckFailedError, HandlerAlreadyRunError,
                                           InvalidCheckSuiteError, InvalidInputFileError, InvalidFileFormatError,
                                           InvalidRecipientError, UnmatchedFilesError)
+from aodncore.pipeline.statequery import StateQuery
 from aodncore.pipeline.steps import NotifyList
 from aodncore.testlib import DummyHandler, HandlerTestCase, dest_path_testing, get_nonexistent_path, mock
 from aodncore.util import WriteOnceOrderedDict
@@ -399,6 +400,10 @@ class TestDummyHandler(HandlerTestCase):
     def test_opendap_root(self):
         handler = self.run_handler(self.temp_nc_file)
         self.assertEqual(handler.opendap_root, 'http://opendap.example.com')
+
+    def test_state_query(self):
+        handler = self.handler_class(self.temp_nc_file)
+        self.assertIsInstance(handler.state_query, StateQuery)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When this lazy property was migrated to the new decorated style, it retained the old manual lazy pattern code in the body, rather than just returning the object and letting the decorator handle the laziness.