### PR TITLE
Add a log message to make it clearer when users are excluded from not…

### DIFF
--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -903,6 +903,10 @@ class HandlerBase(object):
                 if not isinstance(exception, (InvalidConfigError, MissingConfigParameterError)):
                     should_notify.extend(notify_params_dict.get('owner_notify_list', []))
 
+                if notify_params_dict.get('error_notify_list'):
+                    self.logger.warning("exception is not a user-correctable problem, "
+                                        "excluding 'error_notify_list' from notification")
+
             else:
                 self.logger.error(format_exception(exception))
                 self._error_details = str(exception)


### PR DESCRIPTION
…ification

This makes it clearer as to why the configured error recipients are *not* notified when the error type is not a PipelineProcessingError (which is the only type of exception which is forwarded to end users)