### PR TITLE
S3 retry update

### DIFF
--- a/aodncore/pipeline/storage.py
+++ b/aodncore/pipeline/storage.py
@@ -2,6 +2,7 @@ import abc
 import errno
 import os
 from datetime import datetime
+from httplib import IncompleteRead
 
 import boto3
 from botocore.exceptions import ClientError, ConnectionError
@@ -257,7 +258,7 @@ class S3StorageBroker(BaseStorageBroker):
         'tries': 3,
         'delay': 5,
         'backoff': 2,
-        'exceptions': (ClientError, ConnectionError)
+        'exceptions': (ClientError, ConnectionError, IncompleteRead)
     }
 
     def __init__(self, bucket, prefix):

--- a/aodncore/pipeline/storage.py
+++ b/aodncore/pipeline/storage.py
@@ -3,6 +3,7 @@ import errno
 import os
 from datetime import datetime
 from httplib import IncompleteRead
+from ssl import SSLError
 
 import boto3
 from botocore.exceptions import ClientError, ConnectionError
@@ -258,7 +259,7 @@ class S3StorageBroker(BaseStorageBroker):
         'tries': 3,
         'delay': 5,
         'backoff': 2,
-        'exceptions': (ClientError, ConnectionError, IncompleteRead)
+        'exceptions': (ClientError, ConnectionError, IncompleteRead, SSLError)
     }
 
     def __init__(self, bucket, prefix):


### PR DESCRIPTION
Update list of retried exceptions to include recently occurring ones from logs. Enhance tests to better cover this retrying logic.

```
tasks.ACORN.log:2018-10-22 20:05:29,021 ERROR tasks.ACORN[c2a8103e-55af-4c54-b7ae-3e1dbe0a6af1] StorageBrokerError: error querying storage: SSLError: ('The read operation timed out',)
tasks.ACORN.log:StorageBrokerError: error querying storage: SSLError: ('The read operation timed out',)
tasks.ACORN.log:2018-10-31 15:52:09,739 ERROR tasks.ACORN[3e9f05ff-a878-4239-93de-0a77c0de16d5] StorageBrokerError: error querying storage: SSLError: ('The read operation timed out',)
tasks.ACORN.log:StorageBrokerError: error querying storage: SSLError: ('The read operation timed out',)
tasks.ACORN.log:2019-02-03 15:49:47,056 ERROR tasks.ACORN[139a25dc-a9f3-4f60-a0ac-3b020fd1d493] StorageBrokerError: error querying storage: IncompleteRead: IncompleteRead(0 bytes read)
tasks.ACORN.log:StorageBrokerError: error querying storage: IncompleteRead: IncompleteRead(0 bytes read)

```