### PR TITLE
Implement asynchronous compliance checking

### DIFF
--- a/aodncore/pipeline/common.py
+++ b/aodncore/pipeline/common.py
@@ -30,13 +30,18 @@ class CheckResult(object):
     """Simple container class to hold a check result
     """
 
-    def __init__(self, compliant, log, errors=False):
+    def __init__(self, path, compliant, log, errors=False):
+        self._path = path
         self._compliant = compliant
         self._log = log
         self._errors = errors
 
     def __iter__(self):
         return iter_public_attributes(self)
+
+    @property
+    def path(self):
+        return self._path
 
     @property
     def compliant(self):

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -171,6 +171,10 @@ class PipelineFile(object):
     def check_result(self, check_result):
         validate_checkresult(check_result)
 
+        if check_result.path != self.src_path:
+            raise ValueError("invalid check result. CheckResult.path must match "
+                             "PipelineFile.src_path attribute, '{self.src_path}'".format(self=self))
+
         self._is_checked = True
         self._check_result = check_result
         self._post_property_update({'is_checked': True})

--- a/aodncore/pipeline/schema.py
+++ b/aodncore/pipeline/schema.py
@@ -129,6 +129,14 @@ PIPELINE_CONFIG_SCHEMA = {
             'required': ['handlers_group', 'path_function_group', 'module_versions_group'],
             'additionalProperties': False
         },
+        'check': {
+            'type': 'object',
+            'properties': {
+                'async_mode': {'type': 'string', 'enum': ['pool', 'celery']},
+                'pool_process_count': {'type': 'integer', 'minimum': 1, 'maximum': 8}
+            },
+            'additionalProperties': False
+        },
         'talend': {
             'type': 'object',
             'properties': {

--- a/aodncore/testlib/conf/pipeline.conf
+++ b/aodncore/testlib/conf/pipeline.conf
@@ -27,6 +27,10 @@
     "path_function_group": "pipeline.path_functions",
     "module_versions_group": "pipeline.module_versions"
   },
+  "check": {
+    "async_mode": "pool",
+    "pool_process_count": 2
+  },
   "talend": {
     "talend_log_dir": "/tmp/probs/doesnt/exist/process"
   },

--- a/test_aodncore/pipeline/test_configlib.py
+++ b/test_aodncore/pipeline/test_configlib.py
@@ -40,6 +40,10 @@ REFERENCE_PIPELINE_CONFIG = {
         "path_function_group": "pipeline.path_functions",
         "module_versions_group": "pipeline.module_versions"
     },
+    'check': {
+        'async_mode': 'pool',
+        'pool_process_count': 2
+    },
     'talend': {'talend_log_dir': '/tmp/probs/doesnt/exist/process'},
     'templating': {
         'template_package': 'aodncore.pipeline',

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -37,10 +37,10 @@ class TestPipelineFile(BaseTestCase):
 
     def test_compliance_check(self):
         # Test compliance checking
-        check_runner = get_child_check_runner(PipelineFileCheckType.NC_COMPLIANCE_CHECK, None, self.test_logger,
+        check_runner = get_child_check_runner(PipelineFileCheckType.NC_COMPLIANCE_CHECK, self.config, self.test_logger,
                                               {'checks': ['cf']})
         check_runner.run(PipelineFileCollection(self.pipelinefile))
-        assertCountEqual(self, dict(self.pipelinefile.check_result).keys(), ['compliant', 'errors', 'log'])
+        assertCountEqual(self, dict(self.pipelinefile.check_result).keys(), ['path', 'compliant', 'errors', 'log'])
 
     def test_equal_files(self):
         duplicate_file = PipelineFile(GOOD_NC)
@@ -56,7 +56,7 @@ class TestPipelineFile(BaseTestCase):
         # Test file format checking
         check_runner = get_child_check_runner(PipelineFileCheckType.FORMAT_CHECK, None, self.test_logger)
         check_runner.run(PipelineFileCollection(self.pipelinefile))
-        assertCountEqual(self, dict(self.pipelinefile.check_result).keys(), ['compliant', 'errors', 'log'])
+        assertCountEqual(self, dict(self.pipelinefile.check_result).keys(), ['path', 'compliant', 'errors', 'log'])
 
     def test_nonexistent_attribute(self):
         nonexistent_attribute = str(uuid.uuid4())
@@ -66,8 +66,12 @@ class TestPipelineFile(BaseTestCase):
 
     def test_property_check_result(self):
         self.assertFalse(self.pipelinefile.is_checked)
-        self.pipelinefile.check_result = CheckResult(True, False, None)
+        self.pipelinefile.check_result = CheckResult(self.pipelinefile.src_path, True, False, None)
         self.assertTrue(self.pipelinefile.is_checked)
+
+    def test_property_check_result_invalid_path(self):
+        with self.assertRaises(ValueError):
+            self.pipelinefile.check_result = CheckResult('invalid/path', True, False, None)
 
     def test_property_check_type(self):
         test_value = PipelineFileCheckType.FORMAT_CHECK


### PR DESCRIPTION
Notes:
* there is no threading option for this IO intensive task because of Python's GIL constraint
* Since it is quite IO intensive, it's not feasible to ramp up the number of processes because the load gets too high very quickly, so even 2 processes per pipeline can get pretty heavy pretty quickly
* Since the number of processes is also configured on a per-pipeline basis, this makes the load a bit more unpredictable, because the maximum load depends on the number of active pipelines. Currently, with single process per pipeline the peak load is `max_running_checks = number_of_pipelines`. Updating this to multiprocessing makes it `max_running_checks = number_of_pipelines * num_processes`
* The best way to manage peak load would be to have a single shared checking service, which pipelines would queue their checks into and share a pool of processes, but this is getting kind of awkward because it's already run on Celery and adds more moving parts