### PR TITLE
read event ids for incoming files from uuid_path if it exists

### DIFF
--- a/aodncore/pipeline/schema.py
+++ b/aodncore/pipeline/schema.py
@@ -152,7 +152,8 @@ PIPELINE_CONFIG_SCHEMA = {
             'properties': {
                 'incoming_dir': {'type': 'string'},
                 'logger_name': {'type': 'string'},
-                'task_namespace': {'type': 'string'}
+                'task_namespace': {'type': 'string'},
+                'uuid_path': {'type': 'string'}
             },
             'required': ['incoming_dir', 'logger_name', 'task_namespace'],
             'additionalProperties': False


### PR DESCRIPTION
This adds the feature of being able to provide event-ids from an external source.  This allows for tracking of progress of a file through the pipeline externally via the logs.