### PR TITLE
Update discover_entry_points function to return a list of failed entr…

### DIFF
--- a/aodncore/pipeline/destpath.py
+++ b/aodncore/pipeline/destpath.py
@@ -86,13 +86,14 @@ class PathFunctionResolver(object):
     def _resolve_from_param(self):
         if isinstance(self.function_param, six.string_types):
             # a string parameter is assumed to be referring to an advertised entry point of the same name
+            loaded_functions, failed_functions = self.handler_instance.config.discovered_dest_path_functions
             try:
-                function_ref = self.handler_instance.config.discovered_dest_path_functions[self.function_param]
+                function_ref = loaded_functions[self.function_param]
             except KeyError:
                 message = "{attribute_name} function '{function}' not found in '{functions}'".format(
                     attribute_name=self.attribute_name,
                     function=self.function_param,
-                    functions=self.handler_instance.config.discovered_dest_path_functions)
+                    functions=loaded_functions)
                 raise InvalidPathFunctionError(message)
         elif callable(self.function_param):
             # dest_path_function parameter is already a Callable object, use it

--- a/aodncore/pipeline/destpath.py
+++ b/aodncore/pipeline/destpath.py
@@ -90,11 +90,18 @@ class PathFunctionResolver(object):
             try:
                 function_ref = loaded_functions[self.function_param]
             except KeyError:
-                message = "{attribute_name} function '{function}' not found in '{functions}'".format(
+                if self.function_param in set(failed_functions):
+                    message_template = "{attribute_name} function '{function}' failed to load"
+                else:
+                    message_template = "{attribute_name} function '{function}' not found in '{functions}'"
+
+                message = message_template.format(
                     attribute_name=self.attribute_name,
                     function=self.function_param,
                     functions=loaded_functions)
+
                 raise InvalidPathFunctionError(message)
+
         elif callable(self.function_param):
             # dest_path_function parameter is already a Callable object, use it
             function_ref = self.function_param

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -18,7 +18,7 @@ from .schema import (validate_check_params, validate_custom_params, validate_har
                      validate_resolve_params)
 from .statequery import StateQuery
 from .steps import (get_check_runner, get_harvester_runner, get_notify_runner, get_resolve_runner, get_store_runner)
-from ..util import (discover_entry_points, ensure_regex_list, ensure_writeonceordereddict, format_exception,
+from ..util import (ensure_regex_list, ensure_writeonceordereddict, format_exception,
                     get_file_checksum, iter_public_attributes, lazyproperty, matches_regexes, merge_dicts,
                     validate_relative_path_attr, TemporaryDirectory)
 from ..version import __version__ as _aodncore_version
@@ -536,8 +536,10 @@ class HandlerBase(object):
         """
         versions = {'python': platform.python_version(),
                     'aodncore': _aodncore_version}
-        discovered_versions = discover_entry_points('pipeline.module_versions')
-        versions.update(discovered_versions)
+        loaded_versions, failed_versions = self.config.discovered_module_versions
+        failed_version_dict = dict.fromkeys(failed_versions, 'LOAD_FAILED')
+        versions.update(loaded_versions)
+        versions.update(failed_version_dict)
         return versions
 
     @property

--- a/aodncore/testlib/testutil.py
+++ b/aodncore/testlib/testutil.py
@@ -227,8 +227,8 @@ def get_test_config(temp_dir):
     test_watch_config_file = os.path.join(TESTLIB_CONF_DIR, 'watches.conf')
 
     config = LazyConfigManager()
-    config.__dict__['discovered_dest_path_functions'] = {'dest_path_testing': dest_path_testing}
-    config.__dict__['discovered_handlers'] = {'DummyHandler': DummyHandler}
+    config.__dict__['discovered_dest_path_functions'] = ({'dest_path_testing': dest_path_testing}, [])
+    config.__dict__['discovered_handlers'] = ({'DummyHandler': DummyHandler}, [])
 
     config.__dict__['pipeline_config'] = load_runtime_patched_pipeline_config_file(test_pipeline_config_file,
                                                                                    GLOBAL_TEST_BASE, temp_dir)

--- a/aodncore/util/misc.py
+++ b/aodncore/util/misc.py
@@ -63,14 +63,20 @@ def discover_entry_points(entry_point_group, working_set=pkg_resources.working_s
 
     :param entry_point_group: entry point group name used to find entry points in working set
     :param working_set: :py:class:`pkg_resources.WorkingSet` instance
-    :return: :py:class:`dict` containing each discovered entry point, with keys being the entry point name and values
-        being a reference to the object referenced by the entry point
+    :return: :py:class:`tuple` containing two elements, with the first being a :py:class:`dict` containing each
+        discovered and *successfully loaded* entry point (with keys being the entry point name and values being a
+        reference to the object referenced by the entry point), and the second tuple element being a :py:class:`list` of
+        objects which failed to be loaded
     """
     entry_points = {}
+    failed = []
     for entry_point in working_set.iter_entry_points(entry_point_group):
-        entry_point_object = entry_point.load()
-        entry_points[entry_point.name] = entry_point_object
-    return entry_points
+        try:
+            entry_point_object = entry_point.load()
+            entry_points[entry_point.name] = entry_point_object
+        except ImportError:
+            failed.append(entry_point.name)
+    return entry_points, failed
 
 
 def ensure_regex(o):


### PR DESCRIPTION
…y points instead of raising Exception

This prevents the scenario where the handler will raise an unhandled exception if one of the dependencies has a problem with one of the entry points defined by an external package (e.g. aodndata, aodntools, cc_plugin_imos).
