### PR TITLE
Add PATH to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG BUILDER_UID=9999
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
+ENV PATH /home/builder/.local/bin:$PATH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \


### PR DESCRIPTION
Not essential for builds, but added for consistency with other Dockerfiles, and makes offline Docker containers more friendly.