### PR TITLE
Unpin requirements in setup.py. Add test_requirements.txt file.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 source = aodncore
 omit =
+    setup.py
     test_aodncore/*
     aodncore/util/external/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ addons:
     - libudunits2-dev
 
 install:
-  - pip install -r requirements.txt
-  - pip install .[testing]
-  - pip install pytest
+  - pip install -r test_requirements.txt
   - pip install pytest-cov
   - pip install codecov
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                 }
                 stage('test') {
                     steps {
-                        sh 'pip install --user -e . .[testing]'
+                        sh 'pip install --user -r test_requirements.txt'
                         sh 'python setup.py test'
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                 stage('test') {
                     steps {
                         sh 'pip install --user -r test_requirements.txt'
-                        sh 'python setup.py test'
+                        sh 'pytest'
                     }
                 }
                 stage('package') {

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,17 @@ ENTRY_POINTS = {
 
 INSTALL_REQUIRES = [
     'boto3>=1.9.156',
-    'celery==4.3.0',
+    'celery>=4.3.0',
     'compliance-checker==4.1.1',
-    'Jinja2==2.10.3',
     'jsonschema>=2.6.0',
-    'OWSLib>=0.16.0',
-    'paramiko==2.6.0',
+    'paramiko>=2.6.0',
     'python-magic>=0.4.15',
-    'tabulate==0.8.2',
-    'transitions==0.7.1'
+    'transitions>=0.7.1'
 ]
 
-TESTS_REQUIRE = []
+TESTS_REQUIRE = [
+    'pytest'
+]
 
 EXTRAS_REQUIRE = {
     'testing': TESTS_REQUIRE,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,3 @@
+--index-url https://pypi.python.org/simple/
+-r requirements.txt
+-e .[testing]


### PR DESCRIPTION
* Unpin explicit version requirements (except for compliance-checker due to code compatibility, to revisit later)
* Remove requirements that are installed by a dependency (e.g. by compliance-checker already requires OWSLib and tabulate for example)
* Consolidate test requirements to simplify setup of test environments