### PR TITLE
Add sphinx_rtd_theme to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN wget -q https://bootstrap.pypa.io/get-pip.py \
 RUN pip install \
     Cython==0.29 \
     bump2version==0.5.10 \
-    sphinx==2.2.2
+    sphinx==2.2.2 \
+    sphinx_rtd_theme==0.4.3
 
 RUN useradd --create-home --no-log-init --shell /bin/bash --uid $BUILDER_UID builder
 USER builder


### PR DESCRIPTION
Fixes the following issue when Jenkins attempts to release the docs: 

```
Theme error:
sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.(pip install sphinx_rtd_theme)
Makefile:39: recipe for target 'html' failed
make: *** [html] Error 2
```