### PR TITLE
Set worker_max_tasks_per_child to 1 in Celery config, to prevent long…

### DIFF
--- a/aodncore/pipeline/watch.py
+++ b/aodncore/pipeline/watch.py
@@ -81,16 +81,16 @@ def get_task_name(namespace, function_name):
 
 class CeleryConfig(object):
     # TODO: remove this hardcoding and get values from pipeline_config
-    BROKER_URL = 'amqp://'
-    BROKER_TRANSPORT = 'amqp'
-    CELERY_ACCEPT_CONTENT = ['json']
-    CELERY_TASK_SERIALIZER = 'json'
-    CELERY_RESULT_SERIALIZER = 'json'
+    broker_url = 'amqp://'
+    accept_content = ['json']
+    task_serializer = 'json'
+    result_serializer = 'json'
+    worker_max_tasks_per_child = 1
 
-    CELERY_ROUTES = {}
+    task_routes = {}
 
     def __init__(self, routes=None):
-        self.CELERY_ROUTES = routes or {}
+        self.task_routes = routes or {}
 
 
 def delete_same_name_from_error_store_callback(handler, file_state_manager):

--- a/test_aodncore/pipeline/test_watch.py
+++ b/test_aodncore/pipeline/test_watch.py
@@ -82,12 +82,12 @@ class TestPipelineWatch(BaseTestCase):
 class TestCeleryConfig(BaseTestCase):
     def test_init(self):
         celeryconfig = CeleryConfig()
-        self.assertDictEqual(celeryconfig.CELERY_ROUTES, {})
+        self.assertDictEqual(celeryconfig.task_routes, {})
 
     def test_init_routes(self):
         routes = {'/some/directory': 'UNITTEST'}
         celeryconfig = CeleryConfig(routes)
-        self.assertIs(celeryconfig.CELERY_ROUTES, routes)
+        self.assertIs(celeryconfig.task_routes, routes)
 
 
 class TestCeleryManager(BaseTestCase):


### PR DESCRIPTION
… running workers from consuming excessive memory. 

This will cause celery workers to replace the task process after each file is processed. There is a small overhead, but should be negligible compared with the overall processing time. This ensures that potentially leaky handlers are not left wasting memory.

This is not intended to replace normal good practices in terms of code memory efficiency, but adds a top level safety feature to help prevent leaks from affecting the overall system memory.

Also, updated config items to use Celery 4 naming scheme (lower case, some renamed, remove ignored BROKER_TRANSPORT).