### PR TITLE
Unpin python-dateutil due to upstream issue being resolved

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ INSTALL_REQUIRES = [
     'jsonschema>=2.6.0',
     'OWSLib>=0.16.0',
     'paramiko==2.6.0',
-    'python-dateutil<2.8.1',  # dateutil capped due to: https://github.com/boto/botocore/issues/1872
     'python-magic>=0.4.15',
     'tabulate==0.8.2',
     'transitions==0.7.1'


### PR DESCRIPTION
The upstream botocore issue has now been resolved, so this temporary pinning should be safe to remove now.