### PR TITLE
Refactor StateQuery to provide download methods for child handlers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.14
+current_version = 1.2.0
 commit = False
 tag = False
 tag_name = {new_version}
@@ -25,4 +25,3 @@ replace = __version__ = '{new_version}'
 [bumpversion:file:setup.py]
 search = version='{current_version}',
 replace = version='{new_version}',
-

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -1064,14 +1064,14 @@ class PipelineFileCollection(PipelineFileCollectionBase):
         return cls(PipelineFile.from_remotepipelinefile(f, is_deletion=are_deletions)
                    for f in remotepipelinefilecollection)
 
-    def add(self, pipeline_file, deletion=False, overwrite=False, validate_unique=True, **kwargs):
+    def add(self, pipeline_file, is_deletion=False, overwrite=False, validate_unique=True, **kwargs):
         self.member_validator(pipeline_file)
-        validate_bool(deletion)
+        validate_bool(is_deletion)
 
-        if not isinstance(pipeline_file, self.member_class) and not deletion and not os.path.isfile(pipeline_file):
+        if not isinstance(pipeline_file, self.member_class) and not is_deletion and not os.path.isfile(pipeline_file):
             raise MissingFileError("file '{src}' doesn't exist".format(src=pipeline_file))
 
-        return super().add(pipeline_file, overwrite=overwrite, validate_unique=validate_unique, is_deletion=deletion,
+        return super().add(pipeline_file, overwrite=overwrite, validate_unique=validate_unique, is_deletion=is_deletion,
                            **kwargs)
 
     def _set_attribute(self, attribute, value):

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -263,15 +263,24 @@ class PipelineFile(PipelineFileBase):
             self.publish_type = publish_type
 
     @classmethod
-    def from_remotepipelinefile(cls, remotepipelinefile, is_deletion=False):
+    def from_remotepipelinefile(cls, remotepipelinefile, name=None, is_deletion=False, late_deletion=False,
+                                file_update_callback=None, check_type=None, publish_type=None):
         """Construct a PipelineFile instance from an existing RemotePipelineFile instance
 
         :param remotepipelinefile: RemotePipelineFile instance used to instantiate a PipelineFile instance
-        :param is_deletion: is_deletion flag passed directly to __init__
+        :param name: name flag passed to __init__ (defaults to remotepipelinefile.name)
+        :param is_deletion: is_deletion flag passed to __init__
+        :param late_deletion: late_deletion flag passed to __init__
+        :param file_update_callback: file_update_callback flag passed to __init__
+        :param check_type: check_type flag passed to __init__
+        :param publish_type: publish_type flag passed to __init__
         :return: PipelineFile instance
         """
+        name = name or remotepipelinefile.name
+
         return cls(local_path=remotepipelinefile.local_path, dest_path=remotepipelinefile.dest_path,
-                   name=remotepipelinefile.name, is_deletion=is_deletion)
+                   name=name, is_deletion=is_deletion, late_deletion=late_deletion,
+                   file_update_callback=file_update_callback, check_type=check_type, publish_type=publish_type)
 
     def _key(self):
         return self.name, self.local_path, self.file_checksum

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -984,7 +984,7 @@ class RemotePipelineFileCollection(PipelineFileCollectionBase):
         :return: None
         """
         warnings.warn("This method will be removed in a future version. From a pipeline handler, you should use "
-                      "`self.state_query.download_remotepipelinefilecollection` instead.", DeprecationWarning)
+                      "`self.state_query.download` instead.", DeprecationWarning)
         broker.download(self, local_path)
 
     def keys(self):

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -1028,8 +1028,8 @@ class RemotePipelineFileCollection(PipelineFileCollectionBase):
         :param local_path: local path into which files are downloaded
         :return: None
         """
-        warnings.warn("This method will be removed in a future version. From a pipeline handler, you should use "
-                      "`self.state_query.download` instead.", DeprecationWarning)
+        warnings.warn("This method will be removed in a future version. Please update code to use  "
+                      "`StateQuery.download` instead.", DeprecationWarning)
         broker.download(self, local_path)
 
     def keys(self):

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -208,29 +208,31 @@ class PipelineFile(PipelineFileBase):
     :type late_deletion: :py:class:`bool`
     :param file_update_callback: optional callback to call when a file property is updated
     :type file_update_callback: :py:class:`callable`
+    :param check_type: check type assigned to the file
+    :type check_type: PipelineFileCheckType
+    :param publish_type: publish type assigned to the file
+    :type publish_type: PipelineFilePublishType
     """
     __slots__ = ['_archive_path', '_file_update_callback', '_check_type', '_is_deletion', '_late_deletion',
                  '_publish_type', '_should_archive', '_should_harvest', '_should_store', '_should_undo', '_is_checked',
                  '_is_archived', '_is_harvested', '_is_overwrite', '_is_stored', '_is_harvest_undone',
                  '_is_upload_undone', '_check_result', '_mime_type']
 
-    def __init__(self, local_path, name=None, archive_path=None, dest_path=None, is_deletion=False, late_deletion=False,
-                 file_update_callback=None):
+    def __init__(self, local_path, name=None, archive_path=None, dest_path=None, is_deletion=False,
+                 late_deletion=False, file_update_callback=None, check_type=None, publish_type=None):
         super().__init__(local_path, dest_path)
 
-        self._name = name if name is not None else os.path.basename(local_path)
-
+        # general file attributes, set from parameters
         self._archive_path = archive_path
-
-        self._file_update_callback = None
-        if file_update_callback is not None:
-            self.file_update_callback = file_update_callback
-
-        # processing flags - these express the *intended actions* for the file
-        self._check_type = PipelineFileCheckType.UNSET
         self._is_deletion = is_deletion
         self._late_deletion = late_deletion
-        self._publish_type = PipelineFilePublishType.UNSET
+        self._name = name if name is not None else os.path.basename(local_path)
+
+        # general file attributes, *not* set from parameters
+        self._check_result = None
+        self._mime_type = None
+
+        # processing flags - these express the *intended actions* for the file
         self._should_archive = False
         self._should_harvest = False
         self._should_store = False
@@ -245,8 +247,20 @@ class PipelineFile(PipelineFileBase):
         self._is_harvest_undone = False
         self._is_upload_undone = False
 
-        self._check_result = None
-        self._mime_type = None
+        # attributes which must be assigned by the property setter for validation. The backing variable is intentionally
+        # initialised to a safe default, before the setter is called if the calling code has supplied a value for the
+        # corresponding parameters
+        self._file_update_callback = None
+        if file_update_callback is not None:
+            self.file_update_callback = file_update_callback
+
+        self._check_type = PipelineFileCheckType.UNSET
+        if check_type is not None:
+            self.check_type = check_type
+
+        self._publish_type = PipelineFilePublishType.UNSET
+        if publish_type is not None:
+            self.publish_type = publish_type
 
     @classmethod
     def from_remotepipelinefile(cls, remotepipelinefile, is_deletion=False):

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -1064,14 +1064,15 @@ class PipelineFileCollection(PipelineFileCollectionBase):
         return cls(PipelineFile.from_remotepipelinefile(f, is_deletion=are_deletions)
                    for f in remotepipelinefilecollection)
 
-    def add(self, pipeline_file, deletion=False, overwrite=False, validate_unique=True):
+    def add(self, pipeline_file, deletion=False, overwrite=False, validate_unique=True, **kwargs):
         self.member_validator(pipeline_file)
         validate_bool(deletion)
 
         if not isinstance(pipeline_file, self.member_class) and not deletion and not os.path.isfile(pipeline_file):
             raise MissingFileError("file '{src}' doesn't exist".format(src=pipeline_file))
 
-        return super().add(pipeline_file, overwrite=overwrite, validate_unique=validate_unique, is_deletion=deletion)
+        return super().add(pipeline_file, overwrite=overwrite, validate_unique=validate_unique, is_deletion=deletion,
+                           **kwargs)
 
     def _set_attribute(self, attribute, value):
         for f in self._s:

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -1,6 +1,7 @@
 import abc
 import mimetypes
 import os
+import warnings
 from collections import Counter, MutableSet, OrderedDict
 
 from .common import (FileType, PipelineFilePublishType, PipelineFileCheckType, validate_addition_publishtype,
@@ -982,6 +983,8 @@ class RemotePipelineFileCollection(PipelineFileCollectionBase):
         :param local_path: local path into which files are downloaded
         :return: None
         """
+        warnings.warn("This method will be removed in a future version. From a pipeline handler, you should use "
+                      "`self.state_query.download_remotepipelinefilecollection` instead.", DeprecationWarning)
         broker.download(self, local_path)
 
     def keys(self):

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -1022,6 +1022,16 @@ class HandlerBase(object):
     # "public" methods
     #
 
+    def add_pipelinefile(self, pipeline_file):
+        """Helper method to add a PipelineFile to the handler's file_collection, with the handler instance's
+            file_update_callback method assigned
+
+        :param pipeline_file: PipelineFile object
+        :return: None
+        """
+        self.file_collection.add(pipeline_file)
+        pipeline_file.file_update_callback = self._file_update_callback
+
     def run(self):
         """The entry point to the handler instance. Executes the automatic state machine transitions, and populates the
             :attr:`result` attribute to signal success or failure of the handler instance.

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -1022,15 +1022,21 @@ class HandlerBase(object):
     # "public" methods
     #
 
-    def add_pipelinefile(self, pipeline_file):
-        """Helper method to add a PipelineFile to the handler's file_collection, with the handler instance's
-            file_update_callback method assigned
+    def add_to_collection(self, pipeline_file, **kwargs):
+        """Helper method to add a PipelineFile object or path to the handler's file_collection, with the handler
+        instance's file_update_callback method assigned
 
-        :param pipeline_file: PipelineFile object
+            Note: as this is a wrapper to the PipelineFileCollection.add method, kwargs are *only* applied when
+            pipeline_file is a path (string). When adding an existing PipelineFile object, the object is added "as-is",
+            and attributes must be set explicitly on the object.
+
+        :param pipeline_file: :py:class:`PipelineFile` or file path
+        :param kwargs: keyword arguments passed through to the PipelineFileCollection.add method
         :return: None
         """
-        self.file_collection.add(pipeline_file)
-        pipeline_file.file_update_callback = self._file_update_callback
+        if isinstance(pipeline_file, PipelineFile):
+            pipeline_file.file_update_callback = self._file_update_callback
+        self.file_collection.add(pipeline_file, file_update_callback=self._file_update_callback, **kwargs)
 
     def run(self):
         """The entry point to the handler instance. Executes the automatic state machine transitions, and populates the

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -12,7 +12,7 @@ from .configlib import validate_lazyconfigmanager
 from .destpath import get_path_function
 from .exceptions import (PipelineProcessingError, HandlerAlreadyRunError, InvalidConfigError, InvalidInputFileError,
                          InvalidFileFormatError, MissingConfigParameterError, UnmatchedFilesError)
-from .files import PipelineFile, PipelineFileCollection, ensure_remotepipelinefilecollection
+from .files import PipelineFile, PipelineFileCollection
 from .log import SYSINFO, get_pipeline_logger
 from .schema import (validate_check_params, validate_custom_params, validate_harvest_params, validate_notify_params,
                      validate_resolve_params)
@@ -20,7 +20,7 @@ from .statequery import StateQuery
 from .steps import (get_check_runner, get_harvester_runner, get_notify_runner, get_resolve_runner, get_store_runner)
 from ..util import (ensure_regex_list, ensure_writeonceordereddict, format_exception,
                     get_file_checksum, iter_public_attributes, lazyproperty, matches_regexes, merge_dicts,
-                    validate_relative_path_attr, TemporaryDirectory, DEFAULT_WFS_VERSION)
+                    validate_relative_path_attr, TemporaryDirectory, WfsBroker, DEFAULT_WFS_VERSION)
 from ..version import __version__ as _aodncore_version
 
 __all__ = [
@@ -586,9 +586,9 @@ class HandlerBase(object):
         :return: StateQuery instance
         :rtype: :py:class:`StateQuery`
         """
-        return StateQuery(storage_broker=self._upload_store_runner.broker,
-                          wfs_url=self.config.pipeline_config['global'].get('wfs_url'),
-                          wfs_version=self.config.pipeline_config['global'].get('wfs_version', DEFAULT_WFS_VERSION))
+        wfs_broker = WfsBroker(self.config.pipeline_config['global'].get('wfs_url'),
+                               version=self.config.pipeline_config['global'].get('wfs_version', DEFAULT_WFS_VERSION))
+        return StateQuery(storage_broker=self._upload_store_runner.broker, wfs_broker=wfs_broker)
 
     @property
     def default_addition_publish_type(self):
@@ -1021,20 +1021,6 @@ class HandlerBase(object):
     #
     # "public" methods
     #
-
-    def download_remotepipelinefilecollection(self, remotepipelinefilecollection, local_path=None):
-        """Helper method to download a RemotePipelineFileCollection or RemotePipelineFile using the handler's internal
-            storage broker
-
-        :param remotepipelinefilecollection: RemotePipelineFileCollection to download
-        :param local_path: local path where files will be downloaded. Defaults to the handler's :attr:`temp_dir` value.
-        :return: None
-        """
-        remotepipelinefilecollection = ensure_remotepipelinefilecollection(remotepipelinefilecollection)
-        if local_path is None:
-            local_path = self.temp_dir
-
-        remotepipelinefilecollection.download(self._upload_store_runner.broker, local_path)
 
     def run(self):
         """The entry point to the handler instance. Executes the automatic state machine transitions, and populates the

--- a/aodncore/pipeline/statequery.py
+++ b/aodncore/pipeline/statequery.py
@@ -42,8 +42,8 @@ class StateQuery(object):
         return RemotePipelineFileCollection(self._wfs_broker.query_urls(layer, **kwargs))
 
     def query_wfs_urls_for_layer(self, layer, **kwargs):  # pragma: no cover
-        warnings.warn("This method will be removed in a future version. You should use "
-                      "`self.state_query.query_wfs_urls` instead.", DeprecationWarning)
+        warnings.warn("This method will be removed in a future version. Please update code to use "
+                      "`query_wfs_urls` instead.", DeprecationWarning)
         return self._wfs_broker.query_urls(layer, **kwargs)
 
     def query_wfs_url_exists(self, layer, name):  # pragma: no cover

--- a/aodncore/pipeline/statequery.py
+++ b/aodncore/pipeline/statequery.py
@@ -61,7 +61,7 @@ class StateQuery(object):
         """Helper method to download a RemotePipelineFileCollection or RemotePipelineFile
 
         :param remotepipelinefilecollection: RemotePipelineFileCollection to download
-        :param local_path: local path where files will be downloaded. Defaults to the handler's :attr:`temp_dir` value.
+        :param local_path: local path where files will be downloaded.
         :return: None
         """
         self._storage_broker.download(remotepipelinefilecollection, local_path)

--- a/aodncore/pipeline/statequery.py
+++ b/aodncore/pipeline/statequery.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .files import RemotePipelineFileCollection
 
 __all__ = [
@@ -37,14 +39,20 @@ class StateQuery(object):
         """
         return self._wfs_broker.getfeature_dict(**kwargs)
 
-    def query_wfs_urls_for_layer(self, layer, **kwargs):  # pragma: no cover
-        """Return an IndexedSet of files for a given layer
+    def query_wfs_urls(self, layer, **kwargs):  # pragma: no cover
+        """Return a RemotePipelineFileCollection containing all files for a given layer
 
         :param layer: layer name supplied to GetFeature typename parameter
         :param kwargs: keyword arguments passed to underlying broker method
         :return: RemotePipelineFileCollection containing list of files for the layer
         """
-        return RemotePipelineFileCollection(self._wfs_broker.query_urls_for_layer(layer, **kwargs))
+        return RemotePipelineFileCollection(self._wfs_broker.query_urls(layer, **kwargs))
+
+    def query_wfs_urls_for_layer(self, layer, **kwargs):
+        warnings.warn("This method will be removed in a future version. You should use "
+                      "`self.state_query.query_wfs_urls` instead.", DeprecationWarning)
+
+        return self.query_wfs_urls(layer, **kwargs)
 
     def query_wfs_url_exists(self, layer, name):  # pragma: no cover
         """Returns a bool representing whether a given 'file_url' is present in a layer
@@ -53,7 +61,7 @@ class StateQuery(object):
         :param name: 'file_url' inserted into OGC filter, and supplied to GetFeature filter parameter
         :return: list of files for the layer
         """
-        return self._wfs_broker.query_url_exists_for_layer(layer, name)
+        return self._wfs_broker.query_url_exists(layer, name)
 
     def download(self, remotepipelinefilecollection, local_path):
         """Helper method to download a RemotePipelineFileCollection or RemotePipelineFile using the handler's internal

--- a/aodncore/pipeline/statequery.py
+++ b/aodncore/pipeline/statequery.py
@@ -33,7 +33,8 @@ class StateQuery(object):
         return self._wfs_broker.getfeature_dict(**kwargs)
 
     def query_wfs_files(self, layer, **kwargs):  # pragma: no cover
-        """Return a RemotePipelineFileCollection containing all files for a given layer
+        """Return a RemotePipelineFileCollection containing all files for a given layer, 
+        or files matching the filter specified in the kwarg `ogc_expression` (of type OgcExpression)
 
         :param layer: layer name supplied to GetFeature typename parameter
         :param kwargs: keyword arguments passed to underlying broker method

--- a/aodncore/pipeline/statequery.py
+++ b/aodncore/pipeline/statequery.py
@@ -41,11 +41,10 @@ class StateQuery(object):
         """
         return RemotePipelineFileCollection(self._wfs_broker.query_urls(layer, **kwargs))
 
-    def query_wfs_urls_for_layer(self, layer, **kwargs):
+    def query_wfs_urls_for_layer(self, layer, **kwargs):  # pragma: no cover
         warnings.warn("This method will be removed in a future version. You should use "
                       "`self.state_query.query_wfs_urls` instead.", DeprecationWarning)
-
-        return self.query_wfs_urls(layer, **kwargs)
+        return self._wfs_broker.query_urls(layer, **kwargs)
 
     def query_wfs_url_exists(self, layer, name):  # pragma: no cover
         """Returns a bool representing whether a given 'file_url' is present in a layer

--- a/aodncore/pipeline/statequery.py
+++ b/aodncore/pipeline/statequery.py
@@ -15,6 +15,7 @@ class StateQuery(object):
         self._storage_broker = storage_broker
         self._wfs_broker = wfs_broker
 
+    # WFS methods
     @property
     def wfs(self):
         """Read-only property to access the instantiated WebFeatureService object
@@ -22,14 +23,6 @@ class StateQuery(object):
         :return: WebFeatureService instance
         """
         return self._wfs_broker.wfs
-
-    def query_storage(self, query):  # pragma: no cover
-        """Query the storage backend and return existing files matching the given query
-
-        :param query: S3-style prefix for filtering query results
-        :return: dict containing the query results
-        """
-        return self._storage_broker.query(query)
 
     def query_wfs_getfeature_dict(self, **kwargs):
         """Make a GetFeature request, and return the response in a native dict
@@ -63,12 +56,20 @@ class StateQuery(object):
         """
         return self._wfs_broker.query_url_exists(layer, name)
 
+    # Storage methods
     def download(self, remotepipelinefilecollection, local_path):
-        """Helper method to download a RemotePipelineFileCollection or RemotePipelineFile using the handler's internal
-            storage broker
+        """Helper method to download a RemotePipelineFileCollection or RemotePipelineFile
 
         :param remotepipelinefilecollection: RemotePipelineFileCollection to download
         :param local_path: local path where files will be downloaded. Defaults to the handler's :attr:`temp_dir` value.
         :return: None
         """
         self._storage_broker.download(remotepipelinefilecollection, local_path)
+
+    def query_storage(self, query):  # pragma: no cover
+        """Query the storage backend and return existing files matching the given query
+
+        :param query: S3-style prefix for filtering query results
+        :return: dict containing the query results
+        """
+        return self._storage_broker.query(query)

--- a/aodncore/pipeline/statequery.py
+++ b/aodncore/pipeline/statequery.py
@@ -32,28 +32,28 @@ class StateQuery(object):
         """
         return self._wfs_broker.getfeature_dict(**kwargs)
 
-    def query_wfs_urls(self, layer, **kwargs):  # pragma: no cover
+    def query_wfs_files(self, layer, **kwargs):  # pragma: no cover
         """Return a RemotePipelineFileCollection containing all files for a given layer
 
         :param layer: layer name supplied to GetFeature typename parameter
         :param kwargs: keyword arguments passed to underlying broker method
         :return: RemotePipelineFileCollection containing list of files for the layer
         """
-        return RemotePipelineFileCollection(self._wfs_broker.query_urls(layer, **kwargs))
+        return RemotePipelineFileCollection(self._wfs_broker.query_files(layer, **kwargs))
 
     def query_wfs_urls_for_layer(self, layer, **kwargs):  # pragma: no cover
         warnings.warn("This method will be removed in a future version. Please update code to use "
                       "`query_wfs_urls` instead.", DeprecationWarning)
-        return self._wfs_broker.query_urls(layer, **kwargs)
+        return self._wfs_broker.query_files(layer, **kwargs)
 
-    def query_wfs_url_exists(self, layer, name):  # pragma: no cover
+    def query_wfs_file_exists(self, layer, name):  # pragma: no cover
         """Returns a bool representing whether a given 'file_url' is present in a layer
 
         :param layer: layer name supplied to GetFeature typename parameter
         :param name: 'file_url' inserted into OGC filter, and supplied to GetFeature filter parameter
         :return: list of files for the layer
         """
-        return self._wfs_broker.query_url_exists(layer, name)
+        return self._wfs_broker.query_file_exists(layer, name)
 
     # Storage methods
     def download(self, remotepipelinefilecollection, local_path):

--- a/aodncore/pipeline/steps/resolve.py
+++ b/aodncore/pipeline/steps/resolve.py
@@ -420,7 +420,7 @@ class RsyncManifestResolveRunner(BaseManifestResolveRunner):
                 if record.type is RsyncLineType.FILE_ADD:
                     self._collection.add(abs_path)
                 elif record.type is RsyncLineType.FILE_DELETE:
-                    self._collection.add(abs_path, deletion=True)
+                    self._collection.add(abs_path, is_deletion=True)
 
         return self._collection
 

--- a/aodncore/util/wfs.py
+++ b/aodncore/util/wfs.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from collections import OrderedDict
 
 from owslib.etree import etree
@@ -123,6 +124,12 @@ class WfsBroker(object):
         parsed_response = self.getfeature_dict(**getfeature_kwargs)
         file_urls = IndexedSet(f['properties'][url_property_name] for f in parsed_response['features'])
         return file_urls
+
+    def query_urls_for_layer(self, layer, ogc_expression=None, url_property_name=None):
+        warnings.warn("This method will be removed in a future version. From a pipeline handler, you should use "
+                      "`WfsBroker.query_urls` instead.", DeprecationWarning)
+
+        return self.query_urls(layer, ogc_expression=ogc_expression, url_property_name=url_property_name)
 
     def query_url_exists(self, layer, name):
         """Returns a bool representing whether a given 'file_url' is present in a layer

--- a/aodncore/util/wfs.py
+++ b/aodncore/util/wfs.py
@@ -101,7 +101,7 @@ class WfsBroker(object):
         else:  # pragma: no cover
             raise RuntimeError('unable to determine URL property name!')
 
-    def query_urls(self, layer, ogc_expression=None, url_property_name=None):
+    def query_files(self, layer, ogc_expression=None, url_property_name=None):
         """Return an IndexedSet of files for a given layer
 
         :param layer: layer name supplied to GetFeature typename parameter
@@ -129,9 +129,9 @@ class WfsBroker(object):
         warnings.warn("This method will be removed in a future version. Please update code to use "
                       "`query_urls` instead.", DeprecationWarning)
 
-        return self.query_urls(layer, ogc_expression=ogc_expression, url_property_name=url_property_name)
+        return self.query_files(layer, ogc_expression=ogc_expression, url_property_name=url_property_name)
 
-    def query_url_exists(self, layer, name):
+    def query_file_exists(self, layer, name):
         """Returns a bool representing whether a given 'file_url' is present in a layer
 
         :param layer: layer name supplied to GetFeature typename parameter
@@ -140,5 +140,5 @@ class WfsBroker(object):
         """
         url_property_name = self.get_url_property_name(layer)
         ogc_expression = get_ogc_expression_for_file_url(name, property_name=url_property_name)
-        file_urls = self.query_urls(layer, ogc_expression=ogc_expression, url_property_name=url_property_name)
+        file_urls = self.query_files(layer, ogc_expression=ogc_expression, url_property_name=url_property_name)
         return name in file_urls

--- a/aodncore/util/wfs.py
+++ b/aodncore/util/wfs.py
@@ -126,8 +126,8 @@ class WfsBroker(object):
         return file_urls
 
     def query_urls_for_layer(self, layer, ogc_expression=None, url_property_name=None):
-        warnings.warn("This method will be removed in a future version. From a pipeline handler, you should use "
-                      "`WfsBroker.query_urls` instead.", DeprecationWarning)
+        warnings.warn("This method will be removed in a future version. Please update code to use "
+                      "`query_urls` instead.", DeprecationWarning)
 
         return self.query_urls(layer, ogc_expression=ogc_expression, url_property_name=url_property_name)
 

--- a/aodncore/util/wfs.py
+++ b/aodncore/util/wfs.py
@@ -71,7 +71,7 @@ class WfsBroker(object):
         finally:
             response.close()
 
-    def get_url_property_name_for_layer(self, layer):
+    def get_url_property_name(self, layer):
         """Get the URL property name for a given layer
 
         :param layer: schema dict as returned by WebFeatureService.get_schema
@@ -84,7 +84,7 @@ class WfsBroker(object):
         else:  # pragma: no cover
             raise RuntimeError('unable to determine URL property name!')
 
-    def query_urls_for_layer(self, layer, ogc_filter=None, url_property_name=None):
+    def query_urls(self, layer, ogc_filter=None, url_property_name=None):
         """Return an IndexedSet of files for a given layer
 
         :param layer: layer name supplied to GetFeature typename parameter
@@ -94,7 +94,7 @@ class WfsBroker(object):
         """
 
         if url_property_name is None:
-            url_property_name = self.get_url_property_name_for_layer(layer)
+            url_property_name = self.get_url_property_name(layer)
 
         getfeature_kwargs = {
             'typename': [layer],
@@ -108,14 +108,14 @@ class WfsBroker(object):
         file_urls = IndexedSet(f['properties'][url_property_name] for f in parsed_response['features'])
         return file_urls
 
-    def query_url_exists_for_layer(self, layer, name):
+    def query_url_exists(self, layer, name):
         """Returns a bool representing whether a given 'file_url' is present in a layer
 
         :param layer: layer name supplied to GetFeature typename parameter
         :param name: 'file_url' inserted into OGC filter, and supplied to GetFeature filter parameter
         :return: list of files for the layer
         """
-        url_property_name = self.get_url_property_name_for_layer(layer)
+        url_property_name = self.get_url_property_name(layer)
         ogc_filter = get_filter_for_file_url(name, property_name=url_property_name)
-        file_urls = self.query_urls_for_layer(layer, ogc_filter=ogc_filter, url_property_name=url_property_name)
+        file_urls = self.query_urls(layer, ogc_filter=ogc_filter, url_property_name=url_property_name)
         return name in file_urls

--- a/aodncore/version.py
+++ b/aodncore/version.py
@@ -2,4 +2,4 @@
 Updated automatically by the build server
 """
 
-__version__ = '1.1.14'
+__version__ = '1.2.0'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ PACKAGE_SCRIPTS = ['aodncore/bin/drawmachine.py', 'aodncore/pipeline/watchservic
 
 setup(
     name=PACKAGE_NAME,
-    version='1.1.14',
+    version='1.2.0',
     scripts=PACKAGE_SCRIPTS,
     packages=find_packages(exclude=PACKAGE_EXCLUDES),
     package_data=PACKAGE_DATA,

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -413,3 +413,19 @@ class TestDummyHandler(HandlerTestCase):
     def test_state_query(self, mock_webfeatureservice):
         handler = self.handler_class(self.temp_nc_file)
         self.assertIsInstance(handler.state_query, StateQuery)
+
+    def test_add_pipelinefile(self):
+        pf = PipelineFile(self.temp_nc_file)
+        handler = self.handler_class(self.temp_nc_file)
+
+        def _preprocess(self_):
+            self_.add_pipelinefile(pf)
+
+        handler.preprocess = partial(_preprocess, self_=handler)
+        handler.run()
+
+        self.assertEqual(handler._file_update_callback, pf.file_update_callback)
+        self.assertIn(pf, handler.file_collection)
+
+        with self.assertRaises(TypeError):
+            handler.add_pipelinefile(1)

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -5,14 +5,13 @@ from unittest.mock import patch
 
 from jsonschema import ValidationError
 
-from aodncore.pipeline import (PipelineFile, PipelineFileCheckType, PipelineFilePublishType, RemotePipelineFile,
-                               RemotePipelineFileCollection, HandlerResult)
+from aodncore.pipeline import PipelineFile, PipelineFileCheckType, PipelineFilePublishType, HandlerResult
 from aodncore.pipeline.exceptions import (AttributeValidationError, ComplianceCheckFailedError, HandlerAlreadyRunError,
                                           InvalidCheckSuiteError, InvalidInputFileError, InvalidFileFormatError,
                                           InvalidRecipientError, UnmatchedFilesError)
 from aodncore.pipeline.statequery import StateQuery
 from aodncore.pipeline.steps import NotifyList
-from aodncore.testlib import DummyHandler, HandlerTestCase, NullStorageBroker, dest_path_testing, get_nonexistent_path
+from aodncore.testlib import DummyHandler, HandlerTestCase, dest_path_testing, get_nonexistent_path
 from aodncore.util import WriteOnceOrderedDict
 from test_aodncore import TESTDATA_DIR
 
@@ -410,40 +409,7 @@ class TestDummyHandler(HandlerTestCase):
         handler = self.run_handler(self.temp_nc_file)
         self.assertEqual(handler.opendap_root, 'http://opendap.example.com')
 
-    def test_state_query(self):
+    @patch('aodncore.util.wfs.WebFeatureService')
+    def test_state_query(self, mock_webfeatureservice):
         handler = self.handler_class(self.temp_nc_file)
         self.assertIsInstance(handler.state_query, StateQuery)
-
-    def test_download_remotepipelinefilecollection_collection(self):
-        local_path = os.path.join(self.temp_dir, 'local_download_path')
-        broker = NullStorageBroker('')
-
-        remote_collection = RemotePipelineFileCollection([
-            RemotePipelineFile('dest/path/1.nc', name='1.nc'),
-            RemotePipelineFile('dest/path/2.nc', name='2.nc')
-        ])
-
-        handler = self.handler_class(self.temp_nc_file)
-        handler._upload_store_runner.broker = broker
-
-        handler.download_remotepipelinefilecollection(remote_collection, local_path)
-        local_paths = remote_collection.get_attribute_list('local_path')
-        expected = [os.path.join(local_path, rf.dest_path) for rf in remote_collection]
-
-        broker.assert_download_call_count(1)
-        self.assertCountEqual(local_paths, expected)
-
-    def test_download_remotepipelinefilecollection_file(self):
-        local_path = os.path.join(self.temp_dir, 'local_download_path')
-        broker = NullStorageBroker('')
-
-        remote_file = RemotePipelineFile('dest/path/1.nc', name='1.nc')
-
-        handler = self.handler_class(self.temp_nc_file)
-        handler._upload_store_runner.broker = broker
-
-        handler.download_remotepipelinefilecollection(remote_file, local_path)
-        expected = os.path.join(local_path, remote_file.dest_path)
-
-        broker.assert_download_call_count(1)
-        self.assertEqual(remote_file.local_path, expected)

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -91,6 +91,9 @@ class TestPipelineFile(BaseTestCase):
         self.pipelinefile.check_type = test_value
         self.assertIs(self.pipelinefile.check_type, test_value)
 
+        pf = PipelineFile(GOOD_NC, check_type=PipelineFileCheckType.NC_COMPLIANCE_CHECK)
+        self.assertIs(pf.check_type, PipelineFileCheckType.NC_COMPLIANCE_CHECK)
+
         with self.assertRaises(ValueError):
             self.pipelinefile.check_type = 'invalid'
 
@@ -111,6 +114,9 @@ class TestPipelineFile(BaseTestCase):
         test_value = PipelineFilePublishType.HARVEST_ARCHIVE_UPLOAD
         self.pipelinefile.publish_type = test_value
         self.assertIs(self.pipelinefile.publish_type, test_value)
+
+        pf = PipelineFile(GOOD_NC, publish_type=PipelineFilePublishType.ARCHIVE_ONLY)
+        self.assertIs(pf.publish_type, PipelineFilePublishType.ARCHIVE_ONLY)
 
         with self.assertRaises(TypeError):
             self.pipelinefile.publish_type = 'invalid'

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -48,8 +48,25 @@ class TestPipelineFile(BaseTestCase):
         self.remotepipelinefile = RemotePipelineFile(GOOD_NC + '.dest', local_path=GOOD_NC, name='remotepipelinefile')
 
     def test_from_remotepipelinefile(self):
-        expected = PipelineFile(GOOD_NC, dest_path=GOOD_NC + '.dest', name='remotepipelinefile')
-        actual = PipelineFile.from_remotepipelinefile(self.remotepipelinefile)
+        expected = PipelineFile(GOOD_NC, dest_path=GOOD_NC + '.dest', name='remotepipelinefile', is_deletion=False,
+                                late_deletion=True, file_update_callback=lambda **kwargs: None,
+                                check_type=PipelineFileCheckType.NONEMPTY_CHECK,
+                                publish_type=PipelineFilePublishType.ARCHIVE_ONLY)
+
+        actual = PipelineFile.from_remotepipelinefile(self.remotepipelinefile, is_deletion=False, late_deletion=True,
+                                                      file_update_callback=lambda **kwargs: None,
+                                                      check_type=PipelineFileCheckType.NONEMPTY_CHECK,
+                                                      publish_type=PipelineFilePublishType.ARCHIVE_ONLY)
+
+        self.assertEqual(expected, actual)
+
+    def test_from_remotepipelinefile_deletion(self):
+        expected = PipelineFile(GOOD_NC, dest_path=GOOD_NC + '.dest', is_deletion=True, late_deletion=True,
+                                file_update_callback=lambda **kwargs: None)
+
+        actual = PipelineFile.from_remotepipelinefile(self.remotepipelinefile, name='good.nc', is_deletion=True,
+                                                      late_deletion=True, file_update_callback=lambda **kwargs: None)
+
         self.assertEqual(expected, actual)
 
     def test_compliance_check(self):

--- a/test_aodncore/pipeline/test_statequery.py
+++ b/test_aodncore/pipeline/test_statequery.py
@@ -1,14 +1,32 @@
+import json
+import os
+from unittest.mock import patch
+
+from aodncore.pipeline import RemotePipelineFileCollection, RemotePipelineFile, PipelineFile
 from aodncore.pipeline.statequery import StateQuery
 from aodncore.pipeline.storage import get_storage_broker
 from aodncore.testlib import BaseTestCase
+from aodncore.util.wfs import WfsBroker
+from test_aodncore import TESTDATA_DIR
+
+GOOD_NC = os.path.join(TESTDATA_DIR, 'good.nc')
 
 
 class TestStateQuery(BaseTestCase):
-    def setUp(self):
-        self.storage_broker = get_storage_broker(self.config.pipeline_config['global']['error_uri'])
+    @patch('aodncore.util.wfs.WebFeatureService')
+    def setUp(self, mock_webfeatureservice):
+        self.storage_broker = get_storage_broker(self.config.pipeline_config['global']['upload_uri'])
+
+        self.wfs_broker = WfsBroker(self.config.pipeline_config['global']['wfs_url'])
+
+        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
+            self.wfs_broker.wfs.getfeature().getvalue.return_value = f.read()
+
+        with open(os.path.join(TESTDATA_DIR, 'wfs/get_schema.json')) as f:
+            self.wfs_broker.wfs.get_schema.return_value = json.load(f)
 
     def test_no_wfs(self):
-        state_query = StateQuery(storage_broker=self.storage_broker, wfs_url=None)
+        state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=None)
 
         with self.assertRaises(AttributeError):
             _ = state_query.wfs
@@ -18,3 +36,26 @@ class TestStateQuery(BaseTestCase):
 
         with self.assertRaises(AttributeError):
             _ = state_query.query_wfs_url_exists('', '')
+
+    def test_wfs(self):
+        state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=self.wfs_broker)
+        response = state_query.query_wfs_urls_for_layer('anmn_velocity_timeseries_map')
+
+        expected = RemotePipelineFileCollection([
+            RemotePipelineFile(
+                'IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc'),
+            RemotePipelineFile(
+                'IMOS/ANMN/NRS/NRSYON/Velocity/IMOS_ANMN-NRS_AETVZ_20110413T025900Z_NRSYON_FV01_NRSYON-1104-Workhorse-ADCP-27_END-20111014T222900Z_C-20150306T004801Z.nc')
+        ])
+
+        self.assertEqual(expected, response)
+
+    def test_download_remotepipelinefilecollection(self):
+        state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=self.wfs_broker)
+        pipeline_file = PipelineFile(GOOD_NC, dest_path='dest/path/1.nc')
+        self.storage_broker.upload(pipeline_file)
+
+        remote_file = RemotePipelineFile.from_pipelinefile(pipeline_file)
+        state_query.download(remote_file, local_path=self.temp_dir)
+
+        self.assertTrue(os.path.exists(remote_file.local_path))

--- a/test_aodncore/pipeline/test_statequery.py
+++ b/test_aodncore/pipeline/test_statequery.py
@@ -32,14 +32,14 @@ class TestStateQuery(BaseTestCase):
             _ = state_query.wfs
 
         with self.assertRaises(AttributeError):
-            _ = state_query.query_wfs_urls('')
+            _ = state_query.query_wfs_files('')
 
         with self.assertRaises(AttributeError):
-            _ = state_query.query_wfs_url_exists('', '')
+            _ = state_query.query_wfs_file_exists('', '')
 
     def test_wfs(self):
         state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=self.wfs_broker)
-        response = state_query.query_wfs_urls('anmn_velocity_timeseries_map')
+        response = state_query.query_wfs_files('anmn_velocity_timeseries_map')
 
         expected = RemotePipelineFileCollection([
             RemotePipelineFile(

--- a/test_aodncore/pipeline/test_statequery.py
+++ b/test_aodncore/pipeline/test_statequery.py
@@ -32,14 +32,14 @@ class TestStateQuery(BaseTestCase):
             _ = state_query.wfs
 
         with self.assertRaises(AttributeError):
-            _ = state_query.query_wfs_urls_for_layer('')
+            _ = state_query.query_wfs_urls('')
 
         with self.assertRaises(AttributeError):
             _ = state_query.query_wfs_url_exists('', '')
 
     def test_wfs(self):
         state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=self.wfs_broker)
-        response = state_query.query_wfs_urls_for_layer('anmn_velocity_timeseries_map')
+        response = state_query.query_wfs_urls('anmn_velocity_timeseries_map')
 
         expected = RemotePipelineFileCollection([
             RemotePipelineFile(

--- a/test_aodncore/testdata/wfs/GetFeature_filtered.json
+++ b/test_aodncore/testdata/wfs/GetFeature_filtered.json
@@ -1,6 +1,6 @@
 {
   "type": "FeatureCollection",
-  "totalFeatures": 2,
+  "totalFeatures": 1,
   "features": [
     {
       "type": "Feature",
@@ -8,14 +8,6 @@
       "geometry": null,
       "properties": {
         "file_url": "IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc"
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "anmn_velocity_timeseries_map.fid-6f08f674_166ec2b1090_-67e0",
-      "geometry": null,
-      "properties": {
-        "file_url": "IMOS/ANMN/NRS/NRSYON/Velocity/IMOS_ANMN-NRS_AETVZ_20110413T025900Z_NRSYON_FV01_NRSYON-1104-Workhorse-ADCP-27_END-20111014T222900Z_C-20150306T004801Z.nc"
       }
     }
   ],

--- a/test_aodncore/util/test_wfs.py
+++ b/test_aodncore/util/test_wfs.py
@@ -44,7 +44,7 @@ class TestWfsBroker(BaseTestCase):
                          'IMOS/ANMN/NRS/NRSYON/Velocity/IMOS_ANMN-NRS_AETVZ_20110413T025900Z_NRSYON_FV01_NRSYON-1104-Workhorse-ADCP-27_END-20111014T222900Z_C-20150306T004801Z.nc')
 
     def test_get_url_property_name_for_layer(self):
-        propertyname = self.broker.get_url_property_name_for_layer('anmn_velocity_timeseries_map')
+        propertyname = self.broker.get_url_property_name('anmn_velocity_timeseries_map')
         self.assertEqual('file_url', propertyname)
 
     def test_get_url_property_name_for_layer_not_found(self):
@@ -52,20 +52,20 @@ class TestWfsBroker(BaseTestCase):
         self.broker.url_propertyname_candidates = ('nonexistent_property', 'another_nonexistent_property')
 
         with self.assertRaises(RuntimeError):
-            _ = self.broker.get_url_property_name_for_layer('anmn_velocity_timeseries_map')
+            _ = self.broker.get_url_property_name('anmn_velocity_timeseries_map')
 
     def test_query_files_for_layer(self):
-        files_for_layer = self.broker.query_urls_for_layer('anmn_velocity_timeseries_map')
+        files_for_layer = self.broker.query_urls('anmn_velocity_timeseries_map')
         self.assertIsInstance(files_for_layer, IndexedSet)
 
     def test_query_file_exists_for_layer_true(self):
         file_to_check = 'IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc'
 
-        file_exists = self.broker.query_url_exists_for_layer(layer='anmn_velocity_timeseries_map', name=file_to_check)
+        file_exists = self.broker.query_url_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)
         self.assertTrue(file_exists)
 
     def test_query_file_exists_for_layer_false(self):
         file_to_check = "IMOS/ANMN/QLD/GBROTE/Velocity/FILE_THAT_ISNT_IN_RESULTS.nc"
 
-        file_exists = self.broker.query_url_exists_for_layer(layer='anmn_velocity_timeseries_map', name=file_to_check)
+        file_exists = self.broker.query_url_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)
         self.assertFalse(file_exists)

--- a/test_aodncore/util/test_wfs.py
+++ b/test_aodncore/util/test_wfs.py
@@ -3,17 +3,19 @@ import os
 from unittest.mock import patch
 
 from owslib.etree import etree
+from owslib.fes import PropertyIsEqualTo
 
 from aodncore.testlib import BaseTestCase
 from aodncore.util import IndexedSet
-from aodncore.util.wfs import WfsBroker, get_filter_for_file_url
+from aodncore.util.wfs import WfsBroker, get_ogc_expression_for_file_url, ogc_filter_to_string
 from test_aodncore import TESTDATA_DIR
 
 
 class TestPipelineWfs(BaseTestCase):
     def test_get_filter_for_file_url(self):
         file_url = 'IMOS/test/file/url'
-        xml_filter = get_filter_for_file_url(file_url, property_name='file_url')
+        ogc_expression = get_ogc_expression_for_file_url(file_url, property_name='file_url')
+        xml_filter = ogc_filter_to_string(ogc_expression)
 
         root = etree.fromstring(xml_filter)
         property_name = root.findtext('ogc:PropertyName', namespaces=root.nsmap)
@@ -28,13 +30,13 @@ class TestWfsBroker(BaseTestCase):
     def setUp(self, mock_webfeatureservice):
         self.broker = WfsBroker(self.config.pipeline_config['global']['wfs_url'])
 
-        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
-            self.broker.wfs.getfeature().getvalue.return_value = f.read()
-
         with open(os.path.join(TESTDATA_DIR, 'wfs/get_schema.json')) as f:
             self.broker.wfs.get_schema.return_value = json.load(f)
 
     def test_getfeature_dict(self):
+        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
+            self.broker.wfs.getfeature().getvalue.return_value = f.read()
+
         response = self.broker.getfeature_dict(typename='anmn_velocity_timeseries_map', propertyname='file_url')
 
         self.assertEqual(len(response['features']), 2)
@@ -42,6 +44,20 @@ class TestWfsBroker(BaseTestCase):
                          'IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc')
         self.assertEqual(response['features'][1]['properties']['file_url'],
                          'IMOS/ANMN/NRS/NRSYON/Velocity/IMOS_ANMN-NRS_AETVZ_20110413T025900Z_NRSYON_FV01_NRSYON-1104-Workhorse-ADCP-27_END-20111014T222900Z_C-20150306T004801Z.nc')
+
+    def test_getfeature_dict_filter(self):
+        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature_filtered.json')) as f:
+            self.broker.wfs.getfeature().getvalue.return_value = f.read()
+
+        ogc_filter = PropertyIsEqualTo(propertyname='file_url',
+                                       literal='IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc')
+
+        response = self.broker.getfeature_dict(typename='anmn_velocity_timeseries_map', propertyname='file_url',
+                                               filter=ogc_filter)
+
+        self.assertEqual(len(response['features']), 1)
+        self.assertEqual(response['features'][0]['properties']['file_url'],
+                         'IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc')
 
     def test_get_url_property_name_for_layer(self):
         propertyname = self.broker.get_url_property_name('anmn_velocity_timeseries_map')
@@ -55,16 +71,25 @@ class TestWfsBroker(BaseTestCase):
             _ = self.broker.get_url_property_name('anmn_velocity_timeseries_map')
 
     def test_query_files_for_layer(self):
+        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
+            self.broker.wfs.getfeature().getvalue.return_value = f.read()
+
         files_for_layer = self.broker.query_urls('anmn_velocity_timeseries_map')
         self.assertIsInstance(files_for_layer, IndexedSet)
 
     def test_query_file_exists_for_layer_true(self):
+        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
+            self.broker.wfs.getfeature().getvalue.return_value = f.read()
+
         file_to_check = 'IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc'
 
         file_exists = self.broker.query_url_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)
         self.assertTrue(file_exists)
 
     def test_query_file_exists_for_layer_false(self):
+        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
+            self.broker.wfs.getfeature().getvalue.return_value = f.read()
+
         file_to_check = "IMOS/ANMN/QLD/GBROTE/Velocity/FILE_THAT_ISNT_IN_RESULTS.nc"
 
         file_exists = self.broker.query_url_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)

--- a/test_aodncore/util/test_wfs.py
+++ b/test_aodncore/util/test_wfs.py
@@ -74,7 +74,7 @@ class TestWfsBroker(BaseTestCase):
         with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
             self.broker.wfs.getfeature().getvalue.return_value = f.read()
 
-        files_for_layer = self.broker.query_urls('anmn_velocity_timeseries_map')
+        files_for_layer = self.broker.query_files('anmn_velocity_timeseries_map')
         self.assertIsInstance(files_for_layer, IndexedSet)
 
     def test_query_file_exists_for_layer_true(self):
@@ -83,7 +83,7 @@ class TestWfsBroker(BaseTestCase):
 
         file_to_check = 'IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc'
 
-        file_exists = self.broker.query_url_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)
+        file_exists = self.broker.query_file_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)
         self.assertTrue(file_exists)
 
     def test_query_file_exists_for_layer_false(self):
@@ -92,5 +92,5 @@ class TestWfsBroker(BaseTestCase):
 
         file_to_check = "IMOS/ANMN/QLD/GBROTE/Velocity/FILE_THAT_ISNT_IN_RESULTS.nc"
 
-        file_exists = self.broker.query_url_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)
+        file_exists = self.broker.query_file_exists(layer='anmn_velocity_timeseries_map', name=file_to_check)
         self.assertFalse(file_exists)


### PR DESCRIPTION
Following on from https://github.com/aodn/python-aodncore/pull/208

This is how the above PR should have been implemented. The `StateQuery` instance represents the high level "public" interface to any existing state. This provides clarity to child handlers by providing a single "API".

* child handlers can access the resources they need in a simple and consistent way
* breaking changes to aodncore are less likely, since we don't have to worry about a bunch of different edge cases of handlers importing low level objects, and we can maintain and extend this API as appropriate

In addition, to reduce boilerplate in aodndata when adding custom files after input file resolution (e.g. products), PipelineFile's check_type and publish_type attributes may be set during initialisation time and a helper method was added to HandlerBase in order to automatically assign the file update callback attribute.

These are real world examples of recurring patterns in aodndata (which are currently "correct" given the current library, but should be improved):

#### Before
1. files must explicitly add callback or useful logging information about state changes is lost
1. setter(s) for check_type/publish_type must be called separately after initialisation
```python
            product_file = PipelineFile(product_url, file_update_callback=self._file_update_callback)
            product_file.publish_type = PipelineFilePublishType.HARVEST_UPLOAD
            self.file_collection.add(product_file)
```
#### After
1. file is created in one statement
1. child handlers don't need to deal with the callback directly
```python
product_file = PipelineFile(product_path, 
                            publish_type=PipelineFilePublishType.HARVEST_UPLOAD)
self.add_to_collection(product_file)

# OR add the path directly to have the object constructed for you
self.add_to_collection(product_path, publish_type=PipelineFilePublishType.HARVEST_UPLOAD)
```

#### Before
1. handlers wanting to download had to access private attributes
```python
self.input_file_collection.download(self._upload_store_runner.broker, self.temp_dir)
# OR
self.state_query._storage_broker.download(
                RemotePipelineFileCollection(old_metadata_file), (self.temp_dir)
            )
```

#### After
1. handlers can download using supported public methods on the handler's `state_query` instance, without having to dig out the private storage broker objects to do it (as it is intentional that child handlers don't use these directly)
```python
collection = self.state_query.query_wfs_urls('my_layer')
self.state_query.download(collection)
```