### PR TITLE
WfsBroker methods to accept OgcExpression filters not XML

### DIFF
--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -208,29 +208,31 @@ class PipelineFile(PipelineFileBase):
     :type late_deletion: :py:class:`bool`
     :param file_update_callback: optional callback to call when a file property is updated
     :type file_update_callback: :py:class:`callable`
+    :param check_type: check type assigned to the file
+    :type check_type: PipelineFileCheckType
+    :param publish_type: publish type assigned to the file
+    :type publish_type: PipelineFilePublishType
     """
     __slots__ = ['_archive_path', '_file_update_callback', '_check_type', '_is_deletion', '_late_deletion',
                  '_publish_type', '_should_archive', '_should_harvest', '_should_store', '_should_undo', '_is_checked',
                  '_is_archived', '_is_harvested', '_is_overwrite', '_is_stored', '_is_harvest_undone',
                  '_is_upload_undone', '_check_result', '_mime_type']
 
-    def __init__(self, local_path, name=None, archive_path=None, dest_path=None, is_deletion=False, late_deletion=False,
-                 file_update_callback=None):
+    def __init__(self, local_path, name=None, archive_path=None, dest_path=None, is_deletion=False,
+                 late_deletion=False, file_update_callback=None, check_type=None, publish_type=None):
         super().__init__(local_path, dest_path)
 
-        self._name = name if name is not None else os.path.basename(local_path)
-
+        # general file attributes, set from parameters
         self._archive_path = archive_path
-
-        self._file_update_callback = None
-        if file_update_callback is not None:
-            self.file_update_callback = file_update_callback
-
-        # processing flags - these express the *intended actions* for the file
-        self._check_type = PipelineFileCheckType.UNSET
         self._is_deletion = is_deletion
         self._late_deletion = late_deletion
-        self._publish_type = PipelineFilePublishType.UNSET
+        self._name = name if name is not None else os.path.basename(local_path)
+
+        # general file attributes, *not* set from parameters
+        self._check_result = None
+        self._mime_type = None
+
+        # processing flags - these express the *intended actions* for the file
         self._should_archive = False
         self._should_harvest = False
         self._should_store = False
@@ -245,8 +247,20 @@ class PipelineFile(PipelineFileBase):
         self._is_harvest_undone = False
         self._is_upload_undone = False
 
-        self._check_result = None
-        self._mime_type = None
+        # attributes which must be assigned by the property setter for validation. The backing variable is intentionally
+        # initialised to a safe default, before the setter is called if the calling code has supplied a value for the
+        # corresponding parameters
+        self._file_update_callback = None
+        if file_update_callback is not None:
+            self.file_update_callback = file_update_callback
+
+        self._check_type = PipelineFileCheckType.UNSET
+        if check_type is not None:
+            self.check_type = check_type
+
+        self._publish_type = PipelineFilePublishType.UNSET
+        if publish_type is not None:
+            self.publish_type = publish_type
 
     @classmethod
     def from_remotepipelinefile(cls, remotepipelinefile, is_deletion=False):

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -976,7 +976,7 @@ class RemotePipelineFileCollection(PipelineFileCollectionBase):
         :return: None
         """
         warnings.warn("This method will be removed in a future version. From a pipeline handler, you should use "
-                      "`self.state_query.download_remotepipelinefilecollection` instead.", DeprecationWarning)
+                      "`self.state_query.download` instead.", DeprecationWarning)
         broker.download(self, local_path)
 
     def keys(self):

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -9,10 +9,10 @@ from .common import (FileType, PipelineFilePublishType, PipelineFileCheckType, v
                      validate_settable_checktype)
 from .exceptions import AttributeValidationError, DuplicatePipelineFileError, MissingFileError
 from .schema import validate_check_params
-from ..util import (IndexedSet, ensure_regex_list, format_exception, get_file_checksum, iter_public_attributes,
-                    matches_regexes, rm_f, slice_sequence, validate_bool, validate_callable, validate_int,
-                    validate_mapping, validate_nonstring_iterable, validate_regexes, validate_relative_path_attr,
-                    validate_string, validate_type)
+from ..util import (IndexedSet, classproperty, ensure_regex_list, format_exception, get_file_checksum,
+                    iter_public_attributes, matches_regexes, rm_f, slice_sequence, validate_bool, validate_callable,
+                    validate_int, validate_mapping, validate_nonstring_iterable, validate_regexes,
+                    validate_relative_path_attr, validate_string, validate_type)
 
 __all__ = [
     'PipelineFileCollection',
@@ -577,7 +577,7 @@ class PipelineFile(PipelineFileBase):
                                       message="{properties}".format(properties=log_output))
 
 
-class PipelineFileCollectionBase(MutableSet):
+class PipelineFileCollectionBase(MutableSet, metaclass=abc.ABCMeta):
     """A collection base class which implements the MutableSet abstract base class to allow clean set operations, but
     limited to containing only :py:class:`PipelineFile` or :py:class:`RemotePipelineFile`elements and providing specific
     functionality for handling a collection of them (e.g. filtering, generating tabular data, etc.)
@@ -586,18 +586,12 @@ class PipelineFileCollectionBase(MutableSet):
         path, or an :py:class:`Iterable` whose elements are :py:class:`PipelineFile` instances or file paths
     :type data: :py:class:`PipelineFile`, :py:class:`RemotePipelineFile`, :py:class:`str`, :py:class:`Iterable`
     """
-    __slots__ = ['_s', 'member_class', 'member_validator', 'member_from_string_method', 'unique_attributes']
+    __slots__ = ['_s']
 
-    def __init__(self, data=None, member_class=PipelineFile, member_validator=None, member_from_string_method=None,
-                 unique_attributes=()):
+    def __init__(self, data=None):
         super().__init__()
 
         self._s = IndexedSet()
-
-        self.member_class = member_class
-        self.member_validator = member_validator or validate_pipelinefile_or_string
-        self.member_from_string_method = getattr(self, member_from_string_method) or self.get_pipelinefile_from_src_path
-        self.unique_attributes = unique_attributes
 
         if data is not None:
             if isinstance(data, (self.member_class, str)):
@@ -605,11 +599,32 @@ class PipelineFileCollectionBase(MutableSet):
             for f in data:
                 self.add(f)
 
+    @property
+    @abc.abstractmethod
+    def member_class(cls):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def member_from_string_method(self):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def member_validator(cls):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def unique_attributes(cls):
+        raise NotImplementedError
+
     def __bool__(self):
         return bool(self._s)
 
     def __contains__(self, v):
-        return v in self._s
+        element = v if isinstance(v, self.member_class) else self.member_from_string_method(v)
+        return element in self._s
 
     def __getitem__(self, index):
         result = self._s[index]
@@ -963,20 +978,27 @@ class PipelineFileCollectionBase(MutableSet):
                                                                                           duplicates=duplicates))
 
 
+validate_remotepipelinefile_or_string = validate_type((RemotePipelineFile, str))
+
+
 class RemotePipelineFileCollection(PipelineFileCollectionBase):
     """A PipelineFileCollectionBase subclass to hold a set of RemotePipelineFile instances
     """
+    @classproperty
+    def member_class(cls):
+        return RemotePipelineFile
 
-    def __init__(self, *args, **kwargs):
-        kwargs['member_class'] = RemotePipelineFile
-        kwargs['member_validator'] = validate_remotepipelinefile_or_string
-        kwargs['member_from_string_method'] = 'get_pipelinefile_from_dest_path'
-        kwargs['unique_attributes'] = {'local_path', 'dest_path'}
-        super().__init__(*args, **kwargs)
+    @classproperty
+    def member_validator(cls):
+        return validate_remotepipelinefile_or_string
 
-    def __contains__(self, v):
-        element = v if isinstance(v, self.member_class) else self.get_pipelinefile_from_dest_path(v)
-        return element in self._s
+    @property
+    def member_from_string_method(self):
+        return self.get_pipelinefile_from_dest_path
+
+    @classproperty
+    def unique_attributes(cls):
+        return 'local_path', 'dest_path'
 
     @classmethod
     def from_pipelinefilecollection(cls, pipelinefilecollection):
@@ -998,20 +1020,27 @@ class RemotePipelineFileCollection(PipelineFileCollectionBase):
         return self.get_attribute_list('dest_path')
 
 
+validate_pipelinefile_or_string = validate_type((PipelineFile, str))
+
+
 class PipelineFileCollection(PipelineFileCollectionBase):
     """A PipelineFileCollectionBase subclass to hold a set of PipelineFile instances
     """
+    @classproperty
+    def member_class(cls):
+        return PipelineFile
 
-    def __init__(self, *args, **kwargs):
-        kwargs['member_class'] = PipelineFile
-        kwargs['member_validator'] = validate_pipelinefile_or_string
-        kwargs['member_from_string_method'] = 'get_pipelinefile_from_src_path'
-        kwargs['unique_attributes'] = {'archive_path', 'dest_path'}
-        super().__init__(*args, **kwargs)
+    @classproperty
+    def member_validator(cls):
+        return validate_pipelinefile_or_string
 
-    def __contains__(self, v):
-        element = v if isinstance(v, self.member_class) else self.get_pipelinefile_from_src_path(v)
-        return element in self._s
+    @property
+    def member_from_string_method(self):
+        return self.get_pipelinefile_from_src_path
+
+    @classproperty
+    def unique_attributes(cls):
+        return 'archive_path', 'dest_path'
 
     @classmethod
     def from_remotepipelinefilecollection(cls, remotepipelinefilecollection, are_deletions=False):
@@ -1151,9 +1180,9 @@ class PipelineFileCollection(PipelineFileCollectionBase):
 
 validate_pipelinefilecollection = validate_type(PipelineFileCollection)
 validate_pipelinefile_or_pipelinefilecollection = validate_type((PipelineFile, PipelineFileCollection))
-validate_pipelinefile_or_string = validate_type((PipelineFile, str))
+
 
 validate_remotepipelinefilecollection = validate_type(RemotePipelineFileCollection)
 validate_remotepipelinefile_or_remotepipelinefilecollection = validate_type((RemotePipelineFile,
                                                                              RemotePipelineFileCollection))
-validate_remotepipelinefile_or_string = validate_type((RemotePipelineFile, str))
+

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -1,6 +1,7 @@
 import abc
 import mimetypes
 import os
+import warnings
 from collections import Counter, MutableSet, OrderedDict
 
 from .common import (FileType, PipelineFilePublishType, PipelineFileCheckType, validate_addition_publishtype,
@@ -974,6 +975,8 @@ class RemotePipelineFileCollection(PipelineFileCollectionBase):
         :param local_path: local path into which files are downloaded
         :return: None
         """
+        warnings.warn("This method will be removed in a future version. From a pipeline handler, you should use "
+                      "`self.state_query.download_remotepipelinefilecollection` instead.", DeprecationWarning)
         broker.download(self, local_path)
 
     def keys(self):

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -1022,6 +1022,16 @@ class HandlerBase(object):
     # "public" methods
     #
 
+    def add_pipelinefile(self, pipeline_file):
+        """Helper method to add a PipelineFile to the handler's file_collection, with the handler instance's
+            file_update_callback method assigned
+
+        :param pipeline_file: PipelineFile object
+        :return: None
+        """
+        self.file_collection.add(pipeline_file)
+        pipeline_file.file_update_callback = self._file_update_callback
+
     def run(self):
         """The entry point to the handler instance. Executes the automatic state machine transitions, and populates the
             :attr:`result` attribute to signal success or failure of the handler instance.

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -12,7 +12,7 @@ from .configlib import validate_lazyconfigmanager
 from .destpath import get_path_function
 from .exceptions import (PipelineProcessingError, HandlerAlreadyRunError, InvalidConfigError, InvalidInputFileError,
                          InvalidFileFormatError, MissingConfigParameterError, UnmatchedFilesError)
-from .files import PipelineFile, PipelineFileCollection, ensure_remotepipelinefilecollection
+from .files import PipelineFile, PipelineFileCollection
 from .log import SYSINFO, get_pipeline_logger
 from .schema import (validate_check_params, validate_custom_params, validate_harvest_params, validate_notify_params,
                      validate_resolve_params)
@@ -20,7 +20,7 @@ from .statequery import StateQuery
 from .steps import (get_check_runner, get_harvester_runner, get_notify_runner, get_resolve_runner, get_store_runner)
 from ..util import (ensure_regex_list, ensure_writeonceordereddict, format_exception,
                     get_file_checksum, iter_public_attributes, lazyproperty, matches_regexes, merge_dicts,
-                    validate_relative_path_attr, TemporaryDirectory, DEFAULT_WFS_VERSION)
+                    validate_relative_path_attr, TemporaryDirectory, WfsBroker, DEFAULT_WFS_VERSION)
 from ..version import __version__ as _aodncore_version
 
 __all__ = [
@@ -586,9 +586,9 @@ class HandlerBase(object):
         :return: StateQuery instance
         :rtype: :py:class:`StateQuery`
         """
-        return StateQuery(storage_broker=self._upload_store_runner.broker,
-                          wfs_url=self.config.pipeline_config['global'].get('wfs_url'),
-                          wfs_version=self.config.pipeline_config['global'].get('wfs_version', DEFAULT_WFS_VERSION))
+        wfs_broker = WfsBroker(self.config.pipeline_config['global'].get('wfs_url'),
+                               version=self.config.pipeline_config['global'].get('wfs_version', DEFAULT_WFS_VERSION))
+        return StateQuery(storage_broker=self._upload_store_runner.broker, wfs_broker=wfs_broker)
 
     @property
     def default_addition_publish_type(self):
@@ -1021,20 +1021,6 @@ class HandlerBase(object):
     #
     # "public" methods
     #
-
-    def download_remotepipelinefilecollection(self, remotepipelinefilecollection, local_path=None):
-        """Helper method to download a RemotePipelineFileCollection or RemotePipelineFile using the handler's internal
-            storage broker
-
-        :param remotepipelinefilecollection: RemotePipelineFileCollection to download
-        :param local_path: local path where files will be downloaded. Defaults to the handler's :attr:`temp_dir` value.
-        :return: None
-        """
-        remotepipelinefilecollection = ensure_remotepipelinefilecollection(remotepipelinefilecollection)
-        if local_path is None:
-            local_path = self.temp_dir
-
-        remotepipelinefilecollection.download(self._upload_store_runner.broker, local_path)
 
     def run(self):
         """The entry point to the handler instance. Executes the automatic state machine transitions, and populates the

--- a/aodncore/util/wfs.py
+++ b/aodncore/util/wfs.py
@@ -58,15 +58,16 @@ class WfsBroker(object):
         """
         return self._wfs
 
-    def getfeature_dict(self, **kwargs):
+    def getfeature_dict(self, ogc_filter=None, **kwargs):
         """Make a GetFeature request, and return the response in a native dict
 
+        :param ogc_filter: OGC filter expression. If omitted, all features are returned.
         :param kwargs: keyword arguments passed to the underlying WebFeatureService.getfeature method
         :return: dict containing the parsed GetFeature response
         """
+        if ogc_filter:
+            kwargs['filter'] = ogc_filter_to_string(ogc_filter)
         kwargs.pop('outputFormat', None)
-        if 'filter' in kwargs:
-            kwargs['filter'] = ogc_filter_to_string(kwargs['filter'])
         response = self.wfs.getfeature(outputFormat='json', **kwargs)
         response_body = response.getvalue()
         try:
@@ -104,10 +105,7 @@ class WfsBroker(object):
             'propertyname': url_property_name
         }
 
-        if ogc_filter:
-            getfeature_kwargs['filter'] = ogc_filter
-
-        parsed_response = self.getfeature_dict(**getfeature_kwargs)
+        parsed_response = self.getfeature_dict(ogc_filter=ogc_filter, **getfeature_kwargs)
         file_urls = IndexedSet(f['properties'][url_property_name] for f in parsed_response['features'])
         return file_urls
 

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -411,3 +411,19 @@ class TestDummyHandler(HandlerTestCase):
         handler = self.handler_class(self.temp_nc_file)
         self.assertIsInstance(handler.platform_vocab_helper.platform_type_uris_by_category(), dict)
         self.assertEqual(handler.platform_vocab_helper.platform_altlabels_per_preflabel('Vessel')['9VUU'], 'Anro Asia')
+
+    def test_add_pipelinefile(self):
+        pf = PipelineFile(self.temp_nc_file)
+        handler = self.handler_class(self.temp_nc_file)
+
+        def _preprocess(self_):
+            self_.add_pipelinefile(pf)
+
+        handler.preprocess = partial(_preprocess, self_=handler)
+        handler.run()
+
+        self.assertEqual(handler._file_update_callback, pf.file_update_callback)
+        self.assertIn(pf, handler.file_collection)
+
+        with self.assertRaises(TypeError):
+            handler.add_pipelinefile(1)

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -91,6 +91,9 @@ class TestPipelineFile(BaseTestCase):
         self.pipelinefile.check_type = test_value
         self.assertIs(self.pipelinefile.check_type, test_value)
 
+        pf = PipelineFile(GOOD_NC, check_type=PipelineFileCheckType.NC_COMPLIANCE_CHECK)
+        self.assertIs(pf.check_type, PipelineFileCheckType.NC_COMPLIANCE_CHECK)
+
         with self.assertRaises(ValueError):
             self.pipelinefile.check_type = 'invalid'
 
@@ -111,6 +114,9 @@ class TestPipelineFile(BaseTestCase):
         test_value = PipelineFilePublishType.HARVEST_ARCHIVE_UPLOAD
         self.pipelinefile.publish_type = test_value
         self.assertIs(self.pipelinefile.publish_type, test_value)
+
+        pf = PipelineFile(GOOD_NC, publish_type=PipelineFilePublishType.ARCHIVE_ONLY)
+        self.assertIs(pf.publish_type, PipelineFilePublishType.ARCHIVE_ONLY)
 
         with self.assertRaises(ValueError):
             self.pipelinefile.publish_type = 'invalid'

--- a/test_aodncore/pipeline/test_statequery.py
+++ b/test_aodncore/pipeline/test_statequery.py
@@ -1,14 +1,32 @@
+import json
+import os
+from unittest.mock import patch
+
+from aodncore.pipeline import RemotePipelineFileCollection, RemotePipelineFile, PipelineFile
 from aodncore.pipeline.statequery import StateQuery
 from aodncore.pipeline.storage import get_storage_broker
 from aodncore.testlib import BaseTestCase
+from aodncore.util.wfs import WfsBroker
+from test_aodncore import TESTDATA_DIR
+
+GOOD_NC = os.path.join(TESTDATA_DIR, 'good.nc')
 
 
 class TestStateQuery(BaseTestCase):
-    def setUp(self):
-        self.storage_broker = get_storage_broker(self.config.pipeline_config['global']['error_uri'])
+    @patch('aodncore.util.wfs.WebFeatureService')
+    def setUp(self, mock_webfeatureservice):
+        self.storage_broker = get_storage_broker(self.config.pipeline_config['global']['upload_uri'])
+
+        self.wfs_broker = WfsBroker(self.config.pipeline_config['global']['wfs_url'])
+
+        with open(os.path.join(TESTDATA_DIR, 'wfs/GetFeature.json')) as f:
+            self.wfs_broker.wfs.getfeature().getvalue.return_value = f.read()
+
+        with open(os.path.join(TESTDATA_DIR, 'wfs/get_schema.json')) as f:
+            self.wfs_broker.wfs.get_schema.return_value = json.load(f)
 
     def test_no_wfs(self):
-        state_query = StateQuery(storage_broker=self.storage_broker, wfs_url=None)
+        state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=None)
 
         with self.assertRaises(AttributeError):
             _ = state_query.wfs
@@ -18,3 +36,26 @@ class TestStateQuery(BaseTestCase):
 
         with self.assertRaises(AttributeError):
             _ = state_query.query_wfs_url_exists('', '')
+
+    def test_wfs(self):
+        state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=self.wfs_broker)
+        response = state_query.query_wfs_urls_for_layer('anmn_velocity_timeseries_map')
+
+        expected = RemotePipelineFileCollection([
+            RemotePipelineFile(
+                'IMOS/ANMN/QLD/GBROTE/Velocity/IMOS_ANMN-QLD_AETVZ_20140408T102930Z_GBROTE_FV01_GBROTE-1404-AWAC-13_END-20141022T052930Z_C-20150215T063708Z.nc'),
+            RemotePipelineFile(
+                'IMOS/ANMN/NRS/NRSYON/Velocity/IMOS_ANMN-NRS_AETVZ_20110413T025900Z_NRSYON_FV01_NRSYON-1104-Workhorse-ADCP-27_END-20111014T222900Z_C-20150306T004801Z.nc')
+        ])
+
+        self.assertEqual(expected, response)
+
+    def test_download_remotepipelinefilecollection(self):
+        state_query = StateQuery(storage_broker=self.storage_broker, wfs_broker=self.wfs_broker)
+        pipeline_file = PipelineFile(GOOD_NC, dest_path='dest/path/1.nc')
+        self.storage_broker.upload(pipeline_file)
+
+        remote_file = RemotePipelineFile.from_pipelinefile(pipeline_file)
+        state_query.download(remote_file, local_path=self.temp_dir)
+
+        self.assertTrue(os.path.exists(remote_file.local_path))

--- a/test_aodncore/util/test_wfs.py
+++ b/test_aodncore/util/test_wfs.py
@@ -3,6 +3,7 @@ import os
 from unittest.mock import patch
 
 from owslib.etree import etree
+from owslib.fes import PropertyIsEqualTo
 
 from aodncore.testlib import BaseTestCase
 from aodncore.util import IndexedSet
@@ -13,14 +14,11 @@ from test_aodncore import TESTDATA_DIR
 class TestPipelineWfs(BaseTestCase):
     def test_get_filter_for_file_url(self):
         file_url = 'IMOS/test/file/url'
-        xml_filter = get_filter_for_file_url(file_url, property_name='file_url')
+        ogc_filter = get_filter_for_file_url(file_url, property_name='file_url')
 
-        root = etree.fromstring(xml_filter)
-        property_name = root.findtext('ogc:PropertyName', namespaces=root.nsmap)
-        literal = root.findtext('ogc:Literal', namespaces=root.nsmap)
-
-        self.assertEqual(property_name, 'file_url')
-        self.assertEqual(literal, file_url)
+        self.assertIsInstance(ogc_filter, PropertyIsEqualTo)
+        self.assertEqual(ogc_filter.propertyname, 'file_url')
+        self.assertEqual(ogc_filter.literal, file_url)
 
 
 class TestWfsBroker(BaseTestCase):


### PR DESCRIPTION
When querying WFS, we construct filters using `owslib.fes.OgcExpression` objects. We only need to convert them to XML when we send the getFeature request. So I think this should just be done "under the hood" automatically, rather than requiring the hanlder to do it (e.g. [here](https://github.com/aodn/python-aodndata/blob/8de9b2bb20502ccea8407cd8f59ed87525969ce4/aodndata/moorings/products_handler.py#L166)).
Also, I think the use of `ogc_filter` to denote both `OgcExpression` objects and XML was confusing.