### PR TITLE
Pin netCDF4 to <1.5.4 to continue working correctly on Xenial

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 cftime<1.1.1;python_version=='3.5'
+netCDF4<1.5.4;python_version=='3.5'


### PR DESCRIPTION
netCDF4 1.5.4 has dropped support for Python 3.5.