### PR TITLE
Add `smtp_port` to pipeline.conf jsonschema

### DIFF
--- a/aodncore/pipeline/schema.py
+++ b/aodncore/pipeline/schema.py
@@ -117,6 +117,7 @@ PIPELINE_CONFIG_SCHEMA = {
                 'from': {'type': 'string'},
                 'subject': {'type': 'string'},
                 'smtp_server': {'type': 'string'},
+                'smtp_port': {'type': 'integer'},
                 'smtp_user': {'type': 'string'},
                 'smtp_pass': {'type': 'string'}
             },

--- a/aodncore/testlib/conf/pipeline.conf
+++ b/aodncore/testlib/conf/pipeline.conf
@@ -22,6 +22,7 @@
     "from": "info@aodn.org.au",
     "subject": "aodn-pipeline unit testing",
     "smtp_server": "028fbd24-a700-40af-95c9-155c3b023a64",
+    "smtp_port": 587,
     "smtp_user": "ACCESS_KEY",
     "smtp_pass": "SECRET_KEY"
   },

--- a/test_aodncore/pipeline/test_configlib.py
+++ b/test_aodncore/pipeline/test_configlib.py
@@ -186,6 +186,8 @@ class TestConfig(BaseTestCase):
         pipeline_conf_file = os.path.join(CONF_ROOT, 'pipeline.conf')
         config = load_pipeline_config(pipeline_conf_file)
         self.assertDictEqual(REFERENCE_PIPELINE_CONFIG, config)
+        with self.assertNoException():
+            validate_pipeline_config(config)
 
         nonexistent_config_file = get_nonexistent_path()
         with self.assertRaises(InvalidConfigError):

--- a/test_aodncore/pipeline/test_configlib.py
+++ b/test_aodncore/pipeline/test_configlib.py
@@ -6,6 +6,7 @@ from celery import Celery
 
 from aodncore.pipeline.configlib import load_pipeline_config, load_trigger_config, load_watch_config
 from aodncore.pipeline.exceptions import InvalidConfigError
+from aodncore.pipeline.schema import validate_pipeline_config
 from aodncore.testlib import BaseTestCase, conf, get_nonexistent_path
 
 CONF_ROOT = os.path.dirname(inspect.getfile(conf))
@@ -35,6 +36,7 @@ REFERENCE_PIPELINE_CONFIG = {
         'from': 'info@aodn.org.au',
         'subject': 'aodn-pipeline unit testing',
         'smtp_server': '028fbd24-a700-40af-95c9-155c3b023a64',
+        'smtp_port': 587,
         'smtp_user': 'ACCESS_KEY',
         'smtp_pass': 'SECRET_KEY'
     },


### PR DESCRIPTION
Fixes a bug where it was not possible to supply the optional SMTP port configuration item in the pipeline.conf file, due to being missing from the schema definition.