### PR TITLE
Add 'allow_delete_manifests' flag to resolve_params

### DIFF
--- a/aodncore/pipeline/schema.py
+++ b/aodncore/pipeline/schema.py
@@ -177,7 +177,8 @@ PIPELINE_CONFIG_SCHEMA = {
 RESOLVE_PARAMS_SCHEMA = {
     'type': 'object',
     'properties': {
-        'relative_path_root': {'type': 'string'},
+        'allow_delete_manifests': {'type': 'boolean'},
+        'relative_path_root': {'type': 'string'}
     },
     'additionalProperties': False
 }

--- a/aodncore/pipeline/steps/resolve.py
+++ b/aodncore/pipeline/steps/resolve.py
@@ -66,7 +66,10 @@ def get_resolve_runner(input_file, output_dir, config, logger, resolve_params=No
     elif file_type is FileType.SIMPLE_MANIFEST:
         return SimpleManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
     elif file_type is FileType.DELETE_MANIFEST:
-        return DeleteManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
+        delete_manifests_allowed = resolve_params.get('allow_delete_manifests', False) if resolve_params else False
+        if delete_manifests_allowed:
+            return DeleteManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
+        raise InvalidFileFormatError('delete_manifests are not enabled for this pipeline')
     elif file_type is FileType.JSON_MANIFEST:
         return JsonManifestResolveRunner(input_file, output_dir, config, logger, resolve_params)
     elif file_type is FileType.MAP_MANIFEST:

--- a/aodncore/testlib/dummyhandler.py
+++ b/aodncore/testlib/dummyhandler.py
@@ -1,4 +1,4 @@
-from aodncore.pipeline import HandlerBase, PipelineFileCheckType, PipelineFilePublishType
+from aodncore.pipeline import HandlerBase, PipelineFileCheckType, PipelineFileCollection, PipelineFilePublishType
 from aodncore.vocab import PlatformVocabHelper
 
 
@@ -51,8 +51,11 @@ class DummyHandler(HandlerBase):
         :return: None
         """
         self.logger.info("Running preprocess from child class")
-        if len(self.file_collection) > 1:
-            self.file_collection[1].check_type = PipelineFileCheckType.NO_ACTION
+        (
+            PipelineFileCollection(f for f in self.file_collection if f.publish_type.is_addition_type)[1:]
+                .filter_by_attribute_id('check_type', PipelineFileCheckType.UNSET)
+                .set_check_types(PipelineFileCheckType.NO_ACTION)
+        )
 
     def process(self):
         """Here you can run code that needs to run *after* the compliance checker step but *before* the publishing step.

--- a/test_aodncore/pipeline/steps/test_resolve.py
+++ b/test_aodncore/pipeline/steps/test_resolve.py
@@ -61,8 +61,12 @@ class TestPipelineStepsResolve(BaseTestCase):
         self.assertIsInstance(simple_manifest_resolve_runner, SimpleManifestResolveRunner)
 
         delete_manifest_resolve_runner = get_resolve_runner(DELETE_MANIFEST, self.temp_dir, MOCK_CONFIG,
-                                                            self.test_logger)
+                                                            self.test_logger, {'allow_delete_manifests': True})
         self.assertIsInstance(delete_manifest_resolve_runner, DeleteManifestResolveRunner)
+
+        # delete manifests will not be resolved unless 'allow_delete_manifests' is present in resolve_params
+        with self.assertRaises(InvalidFileFormatError):
+            _ = get_resolve_runner(DELETE_MANIFEST, self.temp_dir, MOCK_CONFIG, self.test_logger)
 
         nc_resolve_runner = get_resolve_runner(GOOD_NC, self.temp_dir, MOCK_CONFIG, self.test_logger)
         self.assertIsInstance(nc_resolve_runner, SingleFileResolveRunner)

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -26,6 +26,7 @@ NOT_NETCDF_NC_FILE = os.path.join(TESTDATA_DIR, 'not_a_netcdf_file.nc')
 MAP_MANIFEST = os.path.join(TESTDATA_DIR, 'test.map_manifest')
 RSYNC_MANIFEST = os.path.join(TESTDATA_DIR, 'test.rsync_manifest')
 SIMPLE_MANIFEST = os.path.join(TESTDATA_DIR, 'test.manifest')
+DELETE_MANIFEST = os.path.join(TESTDATA_DIR, 'test.delete_manifest')
 
 
 class TestDummyHandler(HandlerTestCase):
@@ -118,6 +119,12 @@ class TestDummyHandler(HandlerTestCase):
     def test_invalid_resolve_params(self):
         self.run_handler_with_exception(ValidationError, GOOD_NC, resolve_params={'relative_path_root': 0})
         self.run_handler_with_exception(ValidationError, GOOD_NC, resolve_params={'invalid_param': 'value'})
+
+    def test_allow_delete_manifests(self):
+        self.run_handler_with_exception(InvalidFileFormatError, DELETE_MANIFEST)
+        self.run_handler_with_exception(InvalidFileFormatError, DELETE_MANIFEST,
+                                        resolve_params={'allow_delete_manifests': False})
+        self.run_handler(DELETE_MANIFEST, resolve_params={'allow_delete_manifests': True})
 
     def test_nonexistent_file(self):
         nonexistent_file = get_nonexistent_path()


### PR DESCRIPTION
This feature requires that a pipeline(or handler) explicitly allows delete_manifests before resolving them, by setting the flag in the `resolve_params` dictionary.