### PR TITLE
Update validate_membership to make testing Enums work consistently ac…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.5', '3.6' ]
+        python-version: [ '3.5', '3.8' ]
     steps:
     - uses: actions/checkout@v2
     - name: Install libudunits2-dev

--- a/aodncore/util/misc.py
+++ b/aodncore/util/misc.py
@@ -9,6 +9,7 @@ import re
 import sys
 import types
 from collections import Iterable, OrderedDict, Mapping
+from enum import Enum, EnumMeta
 from io import StringIO
 
 import jinja2
@@ -294,6 +295,15 @@ def str_to_list(string_, delimiter=',', strip_method='strip', include_empty=Fals
 
 def validate_membership(c):
     def validate_membership_func(o):
+        # Compatibility fix for Python <3.8.
+        # Python 3.8 raises a TypeError when testing for non-Enum objects, so this causes this function to also raise
+        # a TypeError in earlier Python 3 versions. This can be removed when Python 3.8 becomes the minimum required
+        # version.
+        if isinstance(c, (EnumMeta, Enum)) and not isinstance(o, (EnumMeta, Enum)):
+            raise TypeError(
+                "unsupported operand type(s) for 'in': '%s' and '%s'" % (
+                    type(o).__qualname__, c.__class__.__qualname__))
+
         if o not in c:
             raise ValueError("value '{o}' must be a member of '{c}'".format(o=o, c=c))
 

--- a/test_aodncore/pipeline/steps/test_check.py
+++ b/test_aodncore/pipeline/steps/test_check.py
@@ -16,9 +16,9 @@ WARNING_NC = os.path.join(TESTDATA_DIR, 'test_manifest.nc')
 
 class TestPipelineStepsCheck(BaseTestCase):
     def test_get_check_runner(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             _ = get_child_check_runner(1, None, self.test_logger, None)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             _ = get_child_check_runner('str', None, self.test_logger, None)
 
         with self.assertRaises(InvalidCheckTypeError):

--- a/test_aodncore/pipeline/steps/test_notify.py
+++ b/test_aodncore/pipeline/steps/test_notify.py
@@ -31,9 +31,9 @@ def get_notification_data():
 
 class TestPipelineStepsNotify(BaseTestCase):
     def test_get_check_runner(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             _ = get_child_notify_runner(1, None, None, self.test_logger)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             _ = get_child_notify_runner('str', None, None, self.test_logger)
 
         email_runner = get_child_notify_runner(NotificationRecipientType.EMAIL, None, None, self.test_logger)

--- a/test_aodncore/pipeline/test_dummyHandler.py
+++ b/test_aodncore/pipeline/test_dummyHandler.py
@@ -394,7 +394,7 @@ class TestDummyHandler(HandlerTestCase):
         handler.default_addition_publish_type = PipelineFilePublishType.NO_ACTION
         self.assertIs(handler.default_addition_publish_type, PipelineFilePublishType.NO_ACTION)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             handler.default_addition_publish_type = 'invalid'
 
     def test_property_default_deletion_publish_type(self):
@@ -403,7 +403,7 @@ class TestDummyHandler(HandlerTestCase):
         handler.default_deletion_publish_type = PipelineFilePublishType.NO_ACTION
         self.assertIs(handler.default_deletion_publish_type, PipelineFilePublishType.NO_ACTION)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             handler.default_deletion_publish_type = 'invalid'
 
     def test_opendap_root(self):

--- a/test_aodncore/pipeline/test_files.py
+++ b/test_aodncore/pipeline/test_files.py
@@ -112,7 +112,7 @@ class TestPipelineFile(BaseTestCase):
         self.pipelinefile.publish_type = test_value
         self.assertIs(self.pipelinefile.publish_type, test_value)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.pipelinefile.publish_type = 'invalid'
 
         with self.assertRaises(ValueError):
@@ -918,7 +918,7 @@ class TestPipelineFileCollection(BaseTestCase):
         self.collection.set_publish_types(PipelineFilePublishType.DELETE_UNHARVEST)
         self.assertTrue(all(f.publish_type is PipelineFilePublishType.DELETE_UNHARVEST for f in self.collection))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.collection.set_publish_types('invalid_type')
 
     @patch("aodncore.pipeline.files.get_file_checksum")


### PR DESCRIPTION
…ross Python versions 3.5-3.8 by raising a TypeError when testing for non-Enum members