### PR TITLE
Broker refactor - final tweak

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.14
+current_version = 1.2.0
 commit = False
 tag = False
 tag_name = {new_version}
@@ -25,4 +25,3 @@ replace = __version__ = '{new_version}'
 [bumpversion:file:setup.py]
 search = version='{current_version}',
 replace = version='{new_version}',
-

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -1064,14 +1064,14 @@ class PipelineFileCollection(PipelineFileCollectionBase):
         return cls(PipelineFile.from_remotepipelinefile(f, is_deletion=are_deletions)
                    for f in remotepipelinefilecollection)
 
-    def add(self, pipeline_file, deletion=False, overwrite=False, validate_unique=True, **kwargs):
+    def add(self, pipeline_file, is_deletion=False, overwrite=False, validate_unique=True, **kwargs):
         self.member_validator(pipeline_file)
-        validate_bool(deletion)
+        validate_bool(is_deletion)
 
-        if not isinstance(pipeline_file, self.member_class) and not deletion and not os.path.isfile(pipeline_file):
+        if not isinstance(pipeline_file, self.member_class) and not is_deletion and not os.path.isfile(pipeline_file):
             raise MissingFileError("file '{src}' doesn't exist".format(src=pipeline_file))
 
-        return super().add(pipeline_file, overwrite=overwrite, validate_unique=validate_unique, is_deletion=deletion,
+        return super().add(pipeline_file, overwrite=overwrite, validate_unique=validate_unique, is_deletion=is_deletion,
                            **kwargs)
 
     def _set_attribute(self, attribute, value):

--- a/aodncore/pipeline/steps/resolve.py
+++ b/aodncore/pipeline/steps/resolve.py
@@ -420,7 +420,7 @@ class RsyncManifestResolveRunner(BaseManifestResolveRunner):
                 if record.type is RsyncLineType.FILE_ADD:
                     self._collection.add(abs_path)
                 elif record.type is RsyncLineType.FILE_DELETE:
-                    self._collection.add(abs_path, deletion=True)
+                    self._collection.add(abs_path, is_deletion=True)
 
         return self._collection
 

--- a/aodncore/version.py
+++ b/aodncore/version.py
@@ -2,4 +2,4 @@
 Updated automatically by the build server
 """
 
-__version__ = '1.1.14'
+__version__ = '1.2.0'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ PACKAGE_SCRIPTS = ['aodncore/bin/drawmachine.py', 'aodncore/pipeline/watchservic
 
 setup(
     name=PACKAGE_NAME,
-    version='1.1.14',
+    version='1.2.0',
     scripts=PACKAGE_SCRIPTS,
     packages=find_packages(exclude=PACKAGE_EXCLUDES),
     package_data=PACKAGE_DATA,


### PR DESCRIPTION
I tried to update some of the moorings handlers in aodndata to work with this. It failed when I tried to add an existing URL (not local path) as a deletion, like this (code is [here](https://github.com/aodn/python-aodndata/pull/249/files#diff-09a7042ec760bab6b4b934a62de7068a07696c16998aa211be9c01a5b443ee1dR359), but now updated):
```python
                self.add_to_collection(old_product_url, dest_path=old_product_url,
                                       is_deletion=True, late_deletion=True,
                                       publish_type=PipelineFilePublishType.DELETE_UNHARVEST)
```
I specified it as `is_deletion`, because that's what the arg is called everywhere, _except_ `PipelineFileCollection.add()`, which was calling it `deletion`. So let's make it consistent.

And while I'm at it, let's bump the version number?