### PR TITLE
Wsd testbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libudunits2-dev \
     python3-dev \
     wget \
+    docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
@@ -31,7 +32,7 @@ RUN pip install \
 
 RUN useradd --create-home --no-log-init --shell /bin/bash --uid $BUILDER_UID builder \
     && groupmod -g $DOCKER_GID docker \
-    && usermod -aG docker builder \
+    && usermod -aG docker builder
 
 USER builder
 WORKDIR /home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 ARG BUILDER_UID=9999
+ARG DOCKER_GID=9999
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
@@ -28,6 +29,9 @@ RUN pip install \
     sphinx==2.2.2 \
     sphinx_rtd_theme==0.4.3
 
-RUN useradd --create-home --no-log-init --shell /bin/bash --uid $BUILDER_UID builder
+RUN useradd --create-home --no-log-init --shell /bin/bash --uid $BUILDER_UID builder \
+    && groupmod -g $DOCKER_GID docker \
+    && usermod -aG docker builder \
+
 USER builder
 WORKDIR /home/builder

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,8 @@ pipeline {
         stage('container') {
             agent {
                 dockerfile {
-                    args '-v ${HOME}/bin:${HOME}/bin'
-                    additionalBuildArgs '--build-arg BUILDER_UID=$(id -u)'
+                    args '-v ${HOME}/bin:${HOME}/bin -v /var/run/docker.sock:/var/run/docker.sock'
+                    additionalBuildArgs '--build-arg BUILDER_UID=$(id -u) --build-arg DOCKER_GID=$(stat -c %g /var/run/docker.sock)'
                 }
             }
             stages {
@@ -35,7 +35,9 @@ pipeline {
                 stage('test') {
                     steps {
                         sh 'pip install --user -r test_requirements.txt'
+                        sh 'newgrp docker'
                         sh 'pytest'
+                        sh 'newgrp builder'
                     }
                 }
                 stage('package') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         stage('container') {
             agent {
                 dockerfile {
-                    args '-v ${HOME}/bin:${HOME}/bin -v /var/run/docker.sock:/var/run/docker.sock'
+                    args '-u 498:495 -v ${HOME}/bin:${HOME}/bin -v /var/run/docker.sock:/var/run/docker.sock'
                     additionalBuildArgs '--build-arg BUILDER_UID=$(id -u) --build-arg DOCKER_GID=$(stat -c %g /var/run/docker.sock)'
                 }
             }
@@ -35,9 +35,7 @@ pipeline {
                 stage('test') {
                     steps {
                         sh 'pip install --user -r test_requirements.txt'
-                        sh 'newgrp docker'
                         sh 'pytest'
-                        sh 'newgrp builder'
                     }
                 }
                 stage('package') {


### PR DESCRIPTION
This allows bind mounts the docker socket inside the running container, which allow your tests run docker.

NOTE: This is really bad security practice but it will get you going for now.