### PR TITLE
Add generic csv harvester references to docs

### DIFF
--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -44,8 +44,8 @@ class HandlerBase(object):
     :type input_file: str
 
     :param allowed_archive_path_regexes: List of allowed regular expressions of which
-        :py:attr:`PipelineFile.archive_path` must match at least one. If any non-matching values are found, the handler
-        will exit with an error during the publish step *before* publishing anything.
+        .. note:: :py:attr:`PipelineFile.archive_path` must match at least one. If any non-matching values are found,
+        the handler will exit with an error during the publish step *before* publishing anything.
     :type allowed_archive_path_regexes: list
 
     :param allowed_dest_path_regexes: List of allowed regular expressions of which :py:attr:`PipelineFile.dest_path`
@@ -60,7 +60,7 @@ class HandlerBase(object):
     :param allowed_regexes: List of allowed regular expressions for :py:attr:`input_file`. Non-matching input files will
         cause the handler to exit with an error during the initialise step.
 
-    .. note:: :py:attr:`allowed_regexes` are checked *after* :py:attr:`allowed_extensions`
+        .. note:: :py:attr:`allowed_regexes` are checked *after* :py:attr:`allowed_extensions`
     :type allowed_regexes: list
 
     :param archive_input_file: Flags whether the original input file should be uploaded to the archive, the location of

--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -44,8 +44,8 @@ class HandlerBase(object):
     :type input_file: str
 
     :param allowed_archive_path_regexes: List of allowed regular expressions of which
-        .. note:: :py:attr:`PipelineFile.archive_path` must match at least one. If any non-matching values are found,
-        the handler will exit with an error during the publish step *before* publishing anything.
+        :py:attr:`PipelineFile.archive_path` must match at least one. If any non-matching values are found, the handler
+        will exit with an error during the publish step *before* publishing anything.
     :type allowed_archive_path_regexes: list
 
     :param allowed_dest_path_regexes: List of allowed regular expressions of which :py:attr:`PipelineFile.dest_path`

--- a/aodncore/pipeline/steps/harvest.py
+++ b/aodncore/pipeline/steps/harvest.py
@@ -2,9 +2,10 @@
 
 Harvesting is performed by a :py:class:`BaseHarvesterRunner` class.
 
-This currently only supports "talend" as a harvesting tool, which requires it to perform the steps necessary to generate
-the inputs expected by the AODN Talend wrapper scripts, but is written generically to support other hypothetical
-harvesting processes.
+This currently supports "talend" and "csv" as harvesting tools.
+
+The "talend" harvester runner runs Talend instances as subprocesses, whereas the "csv" harvester runner calls the core
+"DatabaseInteractions" harvester class directly.
 """
 
 import abc

--- a/sphinx/handler.md
+++ b/sphinx/handler.md
@@ -87,7 +87,7 @@ dict is controlled by the ``HARVEST_PARAMS_SCHEMA`` object in the [schema](https
 
 String to inform the harvest step factory function which HarvesterRunner implementation to use during the publish step.
 
-Note: currently the only valid value is 'talend', which is set as the default.
+Note: 'talend' is the default, but 'csv' is also valid.
 
 ##### include_regexes
 * type: ``list``

--- a/sphinx/userdoc.rst
+++ b/sphinx/userdoc.rst
@@ -82,7 +82,7 @@ actions only on files in the collection which have been flagged for that action 
 attribute of the files).
 
 #. determine files flagged as needing to be archived, and upload to 'archive' location
-#. determine files flagged as needing to be harvested, match and execute Talend harvester(s) for files
+#. determine files flagged as needing to be harvested, match and execute Talend (or CSV) harvester(s) for files
 #. determine files flagged as needing to be uploaded or deleted, and perform the necessary storage operation
 
 .. note:: upload/delete operations are collectively referred to in the handler and supporting code as "store" operations


### PR DESCRIPTION
Updated the readthedocs documentation to include references to generic csv harvester - https://github.com/aodn/backlog/issues/3761

_Note: I couldn't get the aodncore documentation to generate a toctree locally, even though I didn't change the reference in the __modules.rst__ file so I'm wondering whether this is part of the deploy script?_

_Also note: the doco version is sourced from `aodncore.version.\_\_version\_\_` which is now set to `0.0.0` - so this will need to be fixed prior to generating the docs - however the document generation stage (in the Jenkinsfile) is currently commented out pending a different issue https://github.com/aodn/backlog/issues/3684)_