### PR TITLE
Build runsheet with recursive dependencies

### DIFF
--- a/aodncore/pipeline/steps/harvest.py
+++ b/aodncore/pipeline/steps/harvest.py
@@ -529,6 +529,12 @@ class CsvHarvesterRunner(BaseHarvesterRunner):
             raise InvalidConfigError('No implementation for {} ingest_type'.format(ingest_type))
 
     def build_dependency_tree(self, obj):
+        """Update one item from the db_objects list to include indirect dependencies.
+        (i.e. dependencies of dependencies, etc...).
+
+        :param obj: dict describing a database object (from db_objects config)
+        :return: copy of obj with updated dependencies
+        """
         def get_parent_dependencies(deps):
             if deps:
                 for d in deps:
@@ -537,9 +543,10 @@ class CsvHarvesterRunner(BaseHarvesterRunner):
             return deps
 
         dependencies = get_parent_dependencies(obj.get('dependencies'))
+        obj_out = dict(obj)  # make a writeable copy
         if dependencies:
-            obj['dependencies'] = list(set(dependencies))
-        return obj
+            obj_out['dependencies'] = list(set(dependencies))
+        return obj_out
 
     def build_runsheet(self, pf):
         """Function to generate a runsheet for the harvest process.

--- a/test_aodncore/pipeline/steps/test_harvest.py
+++ b/test_aodncore/pipeline/steps/test_harvest.py
@@ -653,7 +653,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
             harvester_runner = CsvHarvesterRunner(self.uploader, hp, self.config, self.test_logger)
 
         for obj in harvester_runner.db_objects:
-            harvester_runner.get_recursive_dependencies(obj)
+            harvester_runner.build_dependency_tree(obj)
 
         child = next(filter(lambda x: x['name'] == 'child', harvester_runner.db_objects))
         grandchild = next(filter(lambda x: x['name'] == 'grandchild', harvester_runner.db_objects))

--- a/test_aodncore/pipeline/steps/test_harvest.py
+++ b/test_aodncore/pipeline/steps/test_harvest.py
@@ -10,6 +10,8 @@ from aodncore.pipeline.steps.harvest import (get_harvester_runner, HarvesterMap,
                                              validate_harvester_mapping, CsvHarvesterRunner)
 from aodncore.pipeline.steps.store import StoreRunner
 from aodncore.testlib import BaseTestCase, NullStorageBroker
+from aodncore.util import WriteOnceOrderedDict
+
 from test_aodncore import TESTDATA_DIR
 
 TEST_ROOT = os.path.dirname(__file__)
@@ -605,7 +607,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
 
     def test_harvest_runner_params(self):
         with open(GOOD_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
             harvester_runner = CsvHarvesterRunner(self.uploader, hp, self.config, self.test_logger)
 
         self.assertIsNotNone(harvester_runner.params)
@@ -649,7 +651,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
 
     def test_recursive_dependencies(self):
         with open(RECURSIVE_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
             harvester_runner = CsvHarvesterRunner(self.uploader, hp, self.config, self.test_logger)
 
         child = next(filter(lambda x: x['name'] == 'child', harvester_runner.db_objects))
@@ -667,7 +669,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
 
     def test_build_runsheet(self):
         with open(GOOD_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
             harvester_runner = CsvHarvesterRunner(self.uploader, hp, self.config, self.test_logger)
 
         collection = get_csv_harvest_collection()
@@ -682,7 +684,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
 
     def test_build_runsheet_recursive(self):
         with open(RECURSIVE_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
             harvester_runner = CsvHarvesterRunner(self.uploader, hp, self.config, self.test_logger)
 
         collection = get_csv_harvest_collection()
@@ -702,7 +704,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
         mock_db.return_value.compare_schemas.return_value = True
 
         with open(GOOD_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
         collection = get_csv_harvest_collection()
         harvester_runner = CsvHarvesterRunner(self.uploader, hp, dummy_config(), self.test_logger)
 
@@ -718,7 +720,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
         mock_db.return_value.compare_schemas.return_value = True
 
         with open(BAD_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
         collection = get_csv_harvest_collection()
         harvester_runner = CsvHarvesterRunner(self.uploader, hp, dummy_config(), self.test_logger)
 
@@ -730,7 +732,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
         mock_db.return_value.compare_schemas.return_value = True
 
         with open(INCOMPLETE_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
         collection = get_csv_harvest_collection(additional_files=[ANOTHER_CSV])
         harvester_runner = CsvHarvesterRunner(self.uploader, hp, dummy_config(), self.test_logger)
 
@@ -742,7 +744,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
         mock_db.return_value.compare_schemas.return_value = True
 
         with open(GOOD_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
         collection = get_csv_harvest_collection(additional_files=[ANOTHER_CSV])
         harvester_runner = CsvHarvesterRunner(self.uploader, hp, dummy_config(), self.test_logger)
 
@@ -769,7 +771,7 @@ class TestCsvHarvesterRunner(BaseTestCase):
         mock_db.return_value.compare_schemas.return_value = True
 
         with open(GOOD_HARVEST_PARAMS) as f:
-            hp = json.load(f)
+            hp = json.load(f, object_pairs_hook=WriteOnceOrderedDict)
         collection = get_csv_harvest_collection(with_store=True)
         harvester_runner = CsvHarvesterRunner(self.uploader, hp, dummy_config(), self.test_logger)
 

--- a/test_aodncore/pipeline/steps/test_harvest.py
+++ b/test_aodncore/pipeline/steps/test_harvest.py
@@ -657,10 +657,12 @@ class TestCsvHarvesterRunner(BaseTestCase):
 
         child = next(filter(lambda x: x['name'] == 'child', harvester_runner.db_objects))
         grandchild = next(filter(lambda x: x['name'] == 'grandchild', harvester_runner.db_objects))
+        greatgrandchild = next(filter(lambda x: x['name'] == 'greatgrandchild', harvester_runner.db_objects))
         secondcousin = next(filter(lambda x: x['name'] == 'secondcousin', harvester_runner.db_objects))
         # child and grandchild should list test_table as a dependency, but secondcousing should not
         self.assertTrue('test_table' in child.get('dependencies'))
         self.assertTrue('test_table' in grandchild.get('dependencies'))
+        self.assertTrue('test_table' in greatgrandchild.get('dependencies'))
         self.assertFalse('test_table' in secondcousin.get('dependencies'))
 
     def test_build_runsheet(self):

--- a/test_aodncore/testdata/test.recursive_harvest_params
+++ b/test_aodncore/testdata/test.recursive_harvest_params
@@ -1,0 +1,33 @@
+{
+    "db_schema": "conn",
+    "db_objects": [
+        {
+            "name": "test_table",
+            "type": "table"
+        },
+        {
+            "name": "child",
+            "type": "materialized view",
+            "dependencies": ["test_table"]
+        },
+        {
+            "name": "grandchild",
+            "type": "materialized view",
+            "dependencies": ["child"]
+        },
+        {
+            "name": "cousin",
+            "type": "table"
+        },
+        {
+            "name": "secondcousin",
+            "type": "materialized view",
+            "dependencies": ["cousin"]
+        },
+        {
+            "name": "greatgrandchild",
+            "type": "materialized view",
+            "dependencies": ["grandchild","secondcousin"]
+        }
+    ]
+}


### PR DESCRIPTION
The existing method `build_runsheet` has been modified to:
* iterate over `pipeline_files` instead of `db_objects`
* flag `db_objects[object]` as included if it meets the mapping criteria
* append to list of pipeline files without a matching db_object (table) - for later exception raising (this removes the need to compare each pipeline file against the runsheet)  

The new method `build_dependency_tree` has been added:
* create a new `db_object` with recursive dependencies

I've unit tested this to 3 recursions, but haven't tested in an actual pipeline - the previous commit is an alternative solution based on my original proof of concept, but I think the latest commit is a bit more elegant