### PR TITLE
celery must be less than version 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ ENTRY_POINTS = {
 
 INSTALL_REQUIRES = [
     'boto3>=1.9.156',
-    'celery>=4.3.0',
+    'celery>=4.3.0,<5',
     'compliance-checker==4.1.1',
     'jsonschema>=2.6.0',
     'paramiko>=2.6.0',


### PR DESCRIPTION
celery version 5 introduces new behaviour that is not compatible with our existing watch config