### PR TITLE
Potential way to do versioning based on tags 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore the version file, it's created on install
+aodncore/_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/aodncore/__init__.py
+++ b/aodncore/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "Unknown/Not Installed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
+[tool.setuptools_scm]
+write_to = "aodncore/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ INSTALL_REQUIRES = [
 
 TESTS_REQUIRE = [
     'pytest',
+    'setuptools_scm',
     'testcontainers[postgresql]'
 ]
 


### PR DESCRIPTION
Creating a draft PR for discussion.

This will make it possible to do a local install the "normal" way and get a version number, which is required for the three `python-aodnX` packages to interact with each other. Manually patching the setup.py file is not ideal.

I don't know the impact on the CI process later down the chain, but this _should_ mean that the `bumpversion.sh` can just be removed and the package will install happily.