### PR TITLE
watch service ignore non-existent directories

### DIFF
--- a/aodncore/util/__init__.py
+++ b/aodncore/util/__init__.py
@@ -1,5 +1,5 @@
 from .external import retry_decorator, IndexedSet, classproperty, lazyproperty
-from .fileops import (TemporaryDirectory, extract_gzip, extract_zip, filesystem_sort_key, get_file_checksum,
+from .fileops import (TemporaryDirectory, dir_exists, extract_gzip, extract_zip, filesystem_sort_key, get_file_checksum,
                       is_dir_writable, is_gzip_file, is_jpeg_file, is_json_file, is_netcdf_file, is_nonempty_file,
                       is_pdf_file, is_png_file, is_tiff_file, is_zip_file, list_regular_files, find_file, mkdir_p, rm_f,
                       rm_r, rm_rf, rm_rf, safe_copy_file, safe_move_file, validate_dir_writable, validate_file_writable)

--- a/aodncore/util/fileops.py
+++ b/aodncore/util/fileops.py
@@ -20,6 +20,7 @@ import netCDF4
 
 __all__ = [
     'TemporaryDirectory',
+    'dir_exists',
     'extract_gzip',
     'extract_zip',
     'filesystem_sort_key',
@@ -89,6 +90,14 @@ try:
     TemporaryDirectory = tempfile.TemporaryDirectory
 except AttributeError:
     TemporaryDirectory = _TemporaryDirectory
+
+
+def dir_exists(path):
+    """Check directory exists at a given path returning True or False
+
+    :param path: directory to check
+    """
+    return os.path.isdir(path)
 
 
 def extract_gzip(gzip_path, dest_dir, dest_name=None):

--- a/test_aodncore/util/test_fileops.py
+++ b/test_aodncore/util/test_fileops.py
@@ -5,10 +5,10 @@ import socket
 import uuid
 import zipfile
 from io import open
-from tempfile import mkdtemp, mkstemp
+from tempfile import mkdtemp, mkstemp, TemporaryDirectory
 
 from aodncore.testlib import BaseTestCase, get_nonexistent_path
-from aodncore.util import (extract_gzip, extract_zip, is_gzip_file, is_jpeg_file, is_netcdf_file, is_pdf_file,
+from aodncore.util import (dir_exists, extract_gzip, extract_zip, is_gzip_file, is_jpeg_file, is_netcdf_file, is_pdf_file,
                            is_png_file, is_tiff_file, is_zip_file, list_regular_files, find_file, mkdir_p, rm_f, rm_r,
                            rm_rf, safe_copy_file, safe_move_file, get_file_checksum, TemporaryDirectory)
 from aodncore.util.misc import format_exception
@@ -22,6 +22,14 @@ TIFF_FILE = os.path.join(TESTDATA_DIR, 'aodn.tiff')
 
 
 class TestUtilFileOps(BaseTestCase):
+
+    def test_dir_exists(self):
+
+        tempdir = TemporaryDirectory()
+        self.assertTrue(dir_exists(tempdir.name))
+        os.rmdir(tempdir.name)
+        self.assertFalse(dir_exists(tempdir.name))
+
     def test_extract_gzip(self):
         temp_file_content = str(uuid.uuid4()).encode('utf-8')
 


### PR DESCRIPTION
Backlog: https://github.com/aodn/backlog/issues/4308

In case there is a misconfigured directory (as per this issue: https://github.com/aodn/issues/issues/1257) this prevents the watch service from failing to start by just skipping the directory and logging a warning which could then be picked up elsewhere e.g. sumo logic