### PR TITLE
Pin required compliance-checker version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,2 @@
-cftime<1.1.1;python_version=='3.5'
-netCDF4<1.5.4;python_version=='3.5'
 pyrsistent<0.17
 jsonschema<4.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ ENTRY_POINTS = {
 INSTALL_REQUIRES = [
     'boto3>=1.9.156',
     'celery>=4.3.0',
-    'git+https://github.com/ioos/compliance-checker.git@5.0.1',
+    'compliance-checker @ git+https://github.com/ioos/compliance-checker.git@5.0.1',
     'jsonschema>=2.6.0',
     'paramiko>=2.6.0',
     'python-magic>=0.4.15',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ ENTRY_POINTS = {
 INSTALL_REQUIRES = [
     'boto3>=1.9.156',
     'celery>=4.3.0',
-    'compliance-checker>=4.1.1',
+    'git+https://github.com/ioos/compliance-checker.git@5.0.1',
     'jsonschema>=2.6.0',
     'paramiko>=2.6.0',
     'python-magic>=0.4.15',

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     author_email='developers@emii.org.au',
     description='AODN pipeline library',
     zip_safe=False,
-    python_requires='>=3.5',
+    python_requires='>=3.8',
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     tests_require=TESTS_REQUIRE,
@@ -69,8 +69,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )


### PR DESCRIPTION
This is not the ideal place to have such a strict constraint, but for now it's the easiest way to avoid [bugs in compliance-checker 5.0.2](https://github.com/aodn/PO-Backlog/issues/3092#issuecomment-1324584772) that can incorrectly fail many of our files.

Also cleaned up a couple of references to Python versions < 3.8 that are no longer relevant.