### PR TITLE
1306 fix circular import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
         pip install numpy
         pip install -r test_requirements.txt
         pip install pytest-cov
+        pip list
     - name: Test with pytest
       run: |
         pytest --cov=./ --cov-report=xml

--- a/README.md
+++ b/README.md
@@ -8,5 +8,9 @@ The package provides the base class for each pipeline handler, aodncore.pipeline
 [![coverage](https://codecov.io/gh/aodn/python-aodncore/branch/master/graph/badge.svg)](https://codecov.io/gh/aodn/python-aodncore)
 
 Project documentation is hosted at: https://aodn.github.io/python-aodncore/index.html
+
+## Testing
+You can run pip install -e . from the project root to install the aodn core from local source during testing
+
 ## Licensing
 This project is licensed under the terms of the GNU GPLv3 license.

--- a/aodncore/pipeline/db.py
+++ b/aodncore/pipeline/db.py
@@ -4,7 +4,8 @@ from psycopg2 import sql, extras
 import yaml
 
 from .exceptions import InvalidSQLConnectionError, InvalidSQLTransactionError, MissingFileError
-from ..util import find_file, get_field_type, get_tableschema_descriptor, is_nonstring_iterable
+from ..util import find_file, is_nonstring_iterable
+from ..table import get_field_type, get_tableschema_descriptor
 
 __all__ = [
     'DatabaseInteractions'

--- a/aodncore/pipeline/files.py
+++ b/aodncore/pipeline/files.py
@@ -2,7 +2,13 @@ import abc
 import mimetypes
 import os
 import warnings
-from collections import Counter, MutableSet, OrderedDict
+
+try:
+    # Import of collections stop working after 3.10, use collections.abc
+    from collections.abc import Counter, MutableSet, OrderedDict
+except ImportError:
+    # Python 2, Python < 3.2
+    from collections import Counter, MutableSet, OrderedDict
 
 from .common import (FileType, PipelineFilePublishType, PipelineFileCheckType, validate_addition_publishtype,
                      validate_checkresult, validate_deletion_publishtype, validate_publishtype,

--- a/aodncore/pipeline/steps/check.py
+++ b/aodncore/pipeline/steps/check.py
@@ -9,6 +9,7 @@ The most common use of this step is to test for compliance using the IOOS Compli
 
 import abc
 import itertools
+import logging
 import os
 # from collections import namedtuple
 # import json
@@ -162,6 +163,8 @@ class ComplianceCheckerCheckRunner(BaseCheckRunner):
 
             compliant = all(r.compliant for r in check_results)
             compliance_log = list(itertools.chain.from_iterable(r.log for r in check_results))
+
+            logging.info(check_results)
             errors = any(r.errors for r in check_results)
 
             pipeline_file.check_result = CheckResult(compliant, compliance_log, errors)

--- a/aodncore/pipeline/steps/check.py
+++ b/aodncore/pipeline/steps/check.py
@@ -22,8 +22,8 @@ from .basestep import BaseStepRunner
 from ..common import CheckResult, PipelineFileCheckType, validate_checktype
 from ..exceptions import ComplianceCheckFailedError, InvalidCheckSuiteError, InvalidCheckTypeError, MissingFileError
 from ..files import PipelineFileCollection
-from ...util import (format_exception, is_netcdf_file, is_nonempty_file, CaptureStdIO, find_file,
-                     get_tableschema_descriptor)
+from ...util import (format_exception, is_netcdf_file, is_nonempty_file, CaptureStdIO, find_file)
+from ...table import get_tableschema_descriptor
 
 __all__ = [
     'get_check_runner',

--- a/aodncore/pipeline/steps/check.py
+++ b/aodncore/pipeline/steps/check.py
@@ -9,10 +9,7 @@ The most common use of this step is to test for compliance using the IOOS Compli
 
 import abc
 import itertools
-import logging
 import os
-# from collections import namedtuple
-# import json
 
 import tableschema
 import yaml
@@ -163,8 +160,6 @@ class ComplianceCheckerCheckRunner(BaseCheckRunner):
 
             compliant = all(r.compliant for r in check_results)
             compliance_log = list(itertools.chain.from_iterable(r.log for r in check_results))
-
-            logging.info(check_results)
             errors = any(r.errors for r in check_results)
 
             pipeline_file.check_result = CheckResult(compliant, compliance_log, errors)

--- a/aodncore/pipeline/steps/check.py
+++ b/aodncore/pipeline/steps/check.py
@@ -20,7 +20,7 @@ from compliance_checker.runner import ComplianceChecker, CheckSuite
 
 from .basestep import BaseStepRunner
 from ..common import CheckResult, PipelineFileCheckType, validate_checktype
-from ..exceptions import ComplianceCheckFailedError, InvalidCheckSuiteError, InvalidCheckTypeError, MissingFileError
+from ..exceptions import ComplianceCheckFailedError, InvalidCheckSuiteError, InvalidCheckTypeError
 from ..files import PipelineFileCollection
 from ...util import (format_exception, is_netcdf_file, is_nonempty_file, CaptureStdIO, find_file)
 from ...table import get_tableschema_descriptor

--- a/aodncore/table/__init__.py
+++ b/aodncore/table/__init__.py
@@ -1,0 +1,6 @@
+from .ff import get_field_type, get_tableschema_descriptor
+
+__all__ = [
+    'get_field_type',
+    'get_tableschema_descriptor'
+]

--- a/aodncore/table/ff.py
+++ b/aodncore/table/ff.py
@@ -2,7 +2,7 @@
 """
 
 from tableschema import Schema
-from ..pipeline.exceptions import InvalidSchemaError
+from aodncore.pipeline.exceptions import InvalidSchemaError
 
 __all__ = [
     'get_tableschema_descriptor',

--- a/aodncore/util/__init__.py
+++ b/aodncore/util/__init__.py
@@ -12,7 +12,6 @@ from .misc import (CaptureStdIO, LoggingContext, Pattern, TemplateRenderer, Writ
                    validate_relative_path, validate_relative_path_attr, validate_string, validate_type, generate_id)
 from .process import SystemProcess
 from .wfs import DEFAULT_WFS_VERSION, WfsBroker
-from .ff import get_field_type, get_tableschema_descriptor
 
 __all__ = [
     'CaptureStdIO',
@@ -81,7 +80,5 @@ __all__ = [
     'validate_relative_path',
     'validate_relative_path_attr',
     'validate_string',
-    'validate_type',
-    'get_field_type',
-    'get_tableschema_descriptor'
+    'validate_type'
 ]

--- a/aodncore/util/external/boltons/setutils.py
+++ b/aodncore/util/external/boltons/setutils.py
@@ -14,8 +14,13 @@ from __future__ import print_function
 from __future__ import division
 from bisect import bisect_left
 from itertools import chain, islice
-from collections import MutableSet
 import operator
+
+""" Import of collections after 3.10 will changed to collections.abc """
+try:
+    from collections.abc import MutableSet  # noqa
+except ImportError:
+    from collections import MutableSet  # noqa
 
 try:
     from typeutils import make_sentinel

--- a/aodncore/util/external/boltons/setutils.py
+++ b/aodncore/util/external/boltons/setutils.py
@@ -14,13 +14,15 @@ from __future__ import print_function
 from __future__ import division
 from bisect import bisect_left
 from itertools import chain, islice
-import operator
 
-""" Import of collections after 3.10 will changed to collections.abc """
 try:
-    from collections.abc import MutableSet  # noqa
+    # Import of collections stop working after 3.10, use collections.abc
+    from collections.abc import MutableSet
 except ImportError:
-    from collections import MutableSet  # noqa
+    # Python 2, Python < 3.2
+    from collections import MutableSet
+
+import operator
 
 try:
     from typeutils import make_sentinel

--- a/aodncore/util/misc.py
+++ b/aodncore/util/misc.py
@@ -8,7 +8,14 @@ import os
 import re
 import sys
 import types
-from collections import Iterable, OrderedDict, Mapping
+
+try:
+    # Import of collections stop working after 3.10, use collections.abc
+    from collections.abc import Iterable, OrderedDict, Mapping
+except ImportError:
+    # Python 2, Python < 3.2
+    from collections import Iterable, OrderedDict, Mapping
+
 from enum import Enum, EnumMeta
 from io import StringIO
 import uuid

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ INSTALL_REQUIRES = [
     'tabulate>=0.8.2',
     'transitions>=0.7.1',
     'psycopg2-binary==2.8.6',
+    # Compliance-checker 5.0.2 (currently latest) still have problem with numpy.float
+    # Starting 1.24.0 numpy.float no longer support and should use float instead.
+    'numpy<1.24.0',
     'PyYAML==5.3.1'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ ENTRY_POINTS = {
 INSTALL_REQUIRES = [
     'boto3>=1.9.156',
     'celery>=4.3.0',
-    'compliance-checker @ git+https://github.com/ioos/compliance-checker.git@5.0.1',
+    'compliance-checker @ git+https://github.com/ioos/compliance-checker.git@v5.0.2',
     'jsonschema>=2.6.0',
     'paramiko>=2.6.0',
     'python-magic>=0.4.15',

--- a/test_aodncore/pipeline/steps/test_check.py
+++ b/test_aodncore/pipeline/steps/test_check.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from tempfile import mkstemp
 
@@ -55,8 +56,12 @@ class TestComplianceCheckerRunner(BaseTestCase):
         check_result = collection[0].check_result
 
         self.assertIsInstance(check_result, CheckResult)
-        self.assertTrue(check_result.compliant)
+
+        if check_result.errors:
+            logging.error(check_result.log)
+
         self.assertFalse(check_result.errors)
+        self.assertTrue(check_result.compliant)
         self.assertListEqual(check_result.log, [])
 
     def test_noncompliant_file(self):

--- a/test_aodncore/pipeline/steps/test_check.py
+++ b/test_aodncore/pipeline/steps/test_check.py
@@ -56,12 +56,12 @@ class TestComplianceCheckerRunner(BaseTestCase):
         check_result = collection[0].check_result
 
         self.assertIsInstance(check_result, CheckResult)
+        self.assertTrue(check_result.compliant)
 
         if check_result.errors:
             logging.error(check_result.log)
-
         self.assertFalse(check_result.errors)
-        self.assertTrue(check_result.compliant)
+
         self.assertListEqual(check_result.log, [])
 
     def test_noncompliant_file(self):

--- a/test_aodncore/table/test_ff.py
+++ b/test_aodncore/table/test_ff.py
@@ -3,7 +3,7 @@ import yaml
 from tableschema import Schema
 
 from aodncore.testlib import BaseTestCase
-from aodncore.util import (get_field_type, get_tableschema_descriptor)
+from aodncore.table import (get_field_type, get_tableschema_descriptor)
 from aodncore.pipeline.exceptions import InvalidSchemaError
 
 

--- a/test_aodncore/util/test_fileops.py
+++ b/test_aodncore/util/test_fileops.py
@@ -10,7 +10,7 @@ from tempfile import mkdtemp, mkstemp, TemporaryDirectory
 from aodncore.testlib import BaseTestCase, get_nonexistent_path
 from aodncore.util import (dir_exists, extract_gzip, extract_zip, is_gzip_file, is_jpeg_file, is_netcdf_file, is_pdf_file,
                            is_png_file, is_tiff_file, is_zip_file, list_regular_files, find_file, mkdir_p, rm_f, rm_r,
-                           rm_rf, safe_copy_file, safe_move_file, get_file_checksum, TemporaryDirectory)
+                           rm_rf, safe_copy_file, safe_move_file, get_file_checksum, TemporaryDirectory as TempDir)
 from aodncore.util.misc import format_exception
 
 from test_aodncore import TESTDATA_DIR
@@ -20,6 +20,8 @@ PDF_FILE = os.path.join(TESTDATA_DIR, 'aodn.pdf')
 PNG_FILE = os.path.join(TESTDATA_DIR, 'invalid.png')
 TIFF_FILE = os.path.join(TESTDATA_DIR, 'aodn.tiff')
 
+TEST_ROOT = os.path.join(os.path.dirname(__file__))
+GOOD_NC_GZ_DM01 = os.path.join(TEST_ROOT, "IMOS_OceanCurrent_HV_20000101T000000Z_GSLA_FV02_DM01_C-20200601T010724Z.nc.gz")
 
 class TestUtilFileOps(BaseTestCase):
 
@@ -301,3 +303,12 @@ class TestUtilFileOps(BaseTestCase):
                     "temporary directory is not writable. {e}".format(e=format_exception(e)))
             self.assertTrue(os.path.isfile(temp_file_path))
         self.assertFalse(os.path.exists(d))
+
+    def test_temporary_directory_from_util(self):
+        """
+        Test circular import issue fixed when aodncore.util TemporaryDirectory() function is in use, before change
+        the TemporaryDirectory() function is shield by another import, hence we need to rename the function to TempDir()
+        """
+        with TempDir() as tmpdir:
+            t = os.path.join(tmpdir, os.path.basename(GOOD_NC_GZ_DM01.replace('.gz', '')))
+            self.assertTrue(len(t) > 0)

--- a/test_aodncore/util/test_process.py
+++ b/test_aodncore/util/test_process.py
@@ -53,23 +53,23 @@ class TestUtilProcess(BaseTestCase):
 
     def test_empty_command(self):
         with self.assertRaisesRegex(SystemCommandFailedError,
-                                   'command parameter must be a list if not a bash shell command'):
+                                    'command parameter must be a list if not a bash shell command'):
             _ = SystemProcess(())
 
     def test_empty_shell_command(self):
         with self.assertRaisesRegex(SystemCommandFailedError,
-                                   'command param must not be empty if bash shell command'):
+                                    'command param must not be empty if bash shell command'):
             _ = SystemProcess('', shell=True)
 
     def test_empty_non_string_shell_command(self):
         with self.assertRaisesRegex(SystemCommandFailedError,
-                                   'command param must be a string if bash shell command'):
+                                    'command param must be a string if bash shell command'):
             _ = SystemProcess((), shell=True)
 
     def test_nonexistent_command(self):
         command = [os.path.join('/nonexistent/path/with/a/{uuid}/in/the/middle'.format(uuid=uuid.uuid4()))]
         process = SystemProcess(command)
-        with self.assertRaisesRegex(SystemCommandFailedError, ".*\[Errno 2\] No such file or directory"):
+        with self.assertRaisesRegex(SystemCommandFailedError, ".*\\[Errno 2\\] No such file or directory"):
             process.execute()
 
     def test_execute_failure(self):


### PR DESCRIPTION
test_gsla in python-aodndata shows circular dependency problem before the fix, right now the circular dependency fixed but show other error which didn't seems to be issue cause by this fix.

# Summary of fix
1. Refactor ff.py so that it will not cause circular dependencies.
2. Upgrade compliance-checker to v5.0.2 because it contains a fix to numpy.int (which no longer support as of 1.24.0) 
3. Force the numpy to below 1.24.0 because compliance-checker 5.0.2 still have problem with numpy 1.24.0, it call numpy.float which no longer support.

Item 2 is optional upgrade as we forced the version to below 1.24.0, but we need to upgrade anyway later when we can use numpy 1.24.0 or above.