### PR TITLE
Compliance-checker use obsoleted numpy.float, use 1.23.5 numpy fixed …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy
         pip install -r test_requirements.txt
         pip install pytest-cov
+        pip list
     - name: Test with pytest
       run: |
         pytest --cov=./ --cov-report=xml

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,6 @@
 pyrsistent<0.17
 jsonschema<4.0
+
+# Compliance-checker 5.0.1 have problem with numpy.float / numpy.int
+# Starting 1.24.0 numpy.float / numpy.int no longer supported and should use float / int instead.
+numpy<1.24.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ INSTALL_REQUIRES = [
     'tabulate>=0.8.2',
     'transitions>=0.7.1',
     'psycopg2-binary==2.8.6',
+    # Compliance-checker 5.0.1 have problem with numpy.float / numpy.int
+    # Starting 1.24.0 numpy.float / numpy.int no longer support and should use float / int instead.
+    'numpy<1.24.0',
     'PyYAML==5.3.1'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@ INSTALL_REQUIRES = [
     'tabulate>=0.8.2',
     'transitions>=0.7.1',
     'psycopg2-binary==2.8.6',
-    # Compliance-checker 5.0.1 have problem with numpy.float / numpy.int
-    # Starting 1.24.0 numpy.float / numpy.int no longer support and should use float / int instead.
-    'numpy<1.24.0',
     'PyYAML==5.3.1'
 ]
 


### PR DESCRIPTION
Force numpy version as it is having problem with compliance-checker where it cause issue during import