### PR TITLE
Set default publish type to HARVEST_ONLY when configured

### DIFF
--- a/aodncore/pipeline/handlerbase.py
+++ b/aodncore/pipeline/handlerbase.py
@@ -344,7 +344,7 @@ class HandlerBase(object):
         self.resolve_params = resolve_params
 
         # update default publish types if specified in config and the input file has been copied to the landing bucket
-        if self.custom_params and self.custom_params.get("harvest_only", False) and input_file_copied_to_landing:
+        if input_file_copied_to_landing and self.custom_params and self.custom_params.get("harvest_only", False):
             self.default_addition_publish_type = PipelineFilePublishType.HARVEST_ONLY
 
         # private attributes


### PR DESCRIPTION
... and only if incoming file has been successfully copied to the landing bucket.
Allows specific legacy pipelines to continue harvesting to the database while forwarding the files to Prefect for publishing to S3.

This is to support the gradual migration of legacy pipelines to Prefect. 
See https://github.com/aodn/backlog/issues/6241